### PR TITLE
[BE/Fix] 프로필 사진 설정 수정

### DIFF
--- a/back/src/main/java/org/pknu/weather/service/MemberService.java
+++ b/back/src/main/java/org/pknu/weather/service/MemberService.java
@@ -54,7 +54,7 @@ public class MemberService {
 
         MultipartFile profileImg = memberJoinDTO.getProfileImg();
 
-        if (profileImg != null && profileImg.getContentType().startsWith("image")){
+        if (!profileImg.isEmpty() && profileImg.getContentType().startsWith("image")){
             uploadProfileImageToS3(memberJoinDTO, profileImg);
             removeExProfileImage(member);
         }


### PR DESCRIPTION

### PR 요약 혹은 이슈 번호(링크)
- #154 

### PR 설명
-  사용자의 정보를 수정하는 API에서 프로필 사진을 설정하지 않아도 에러(nullPointException)가 발생하지 않도록 수정
- MemberService.java의 checkNicknameAndSave에서 프로필 사진 정보 null체크가 아닌 isEmpty()로 체크하도록 수정

