### PR TITLE
[BE/Feat] 체감 온도 추가 및 일부 코드 수정

### DIFF
--- a/back/src/main/java/org/pknu/weather/aop/BusinessLogicLoggingAspect.java
+++ b/back/src/main/java/org/pknu/weather/aop/BusinessLogicLoggingAspect.java
@@ -15,8 +15,8 @@ import org.springframework.stereotype.Component;
 public class BusinessLogicLoggingAspect {
 
     // @Transactional 이 붙어있으면서 매개변수 memberId 를 포함하는 모든 메서드들에 대해서 로깅
-    @Around("org.pknu.weather.aop.Pointcuts.transactionalPointcut() && args(memberId,..)")
-    public Object doLog(ProceedingJoinPoint pjp, Long memberId) throws Throwable {
+    @Around("org.pknu.weather.aop.Pointcuts.transactionalPointcut() && args(email,..)")
+    public Object doLog(ProceedingJoinPoint pjp, String email) throws Throwable {
         Signature signature = pjp.getSignature();
 
         String className = signature.getDeclaringTypeName();
@@ -24,12 +24,12 @@ public class BusinessLogicLoggingAspect {
 //        Object[] args = pjp.getArgs();
 
         try {
-            log.info("[memberId = {}] [****\t트랜잭션 시작\t\t****] {}, {}", memberId, className, methodName);
+            log.info("[memberId = {}] [****\t트랜잭션 시작\t\t****] {}, {}", email, className, methodName);
             Object result = pjp.proceed();
-            log.info("[memberId = {}] [****\t트랜잭션 커밋\t\t****] {}, {}", memberId, className, methodName);
+            log.info("[memberId = {}] [****\t트랜잭션 커밋\t\t****] {}, {}", email, className, methodName);
             return result;
         } catch (Exception e) {
-            log.info("[memberId = {}] [****\t트랜잭션 롤백\t\t****] {}, {},", memberId, className, methodName);
+            log.info("[memberId = {}] [****\t트랜잭션 롤백\t\t****] {}, {},", email, className, methodName);
             throw e;
         }
     }

--- a/back/src/main/java/org/pknu/weather/common/utils/SensibleTemperatureUtils.java
+++ b/back/src/main/java/org/pknu/weather/common/utils/SensibleTemperatureUtils.java
@@ -39,13 +39,11 @@ public class SensibleTemperatureUtils {
      * @return 체감온도
      */
     public static double getSensibleTemperature(double ta, double rh, double v) {
-        int season = getCurrentSeason();
-
         if (ta <= 10 && v >= 1.3) {
             return getWinterSensibleTemperature(ta, v);
         }
 
-        if (season >= 5 && season <= 10) {
+        if (ta >= 25) {
             return getSummerSensibleTemperature(ta, rh);
         }
 

--- a/back/src/main/java/org/pknu/weather/common/utils/SensibleTemperatureUtils.java
+++ b/back/src/main/java/org/pknu/weather/common/utils/SensibleTemperatureUtils.java
@@ -1,0 +1,74 @@
+package org.pknu.weather.common.utils;
+
+import java.time.LocalDateTime;
+
+/**
+ * 체감 온도를 계산 하는 유틸 클래스
+ */
+public class SensibleTemperatureUtils {
+
+    /**
+     * 겨울철 체감온도 (기온이 10도 이하, 풍속이 1.3m/s 이하일 때 작동)
+     *
+     * @param ta 기온
+     * @param v  10분 평균 풍속, 그냥 풍속으로 계싼해도 무방함
+     */
+    private static double getWinterSensibleTemperature(double ta, double v) {
+        double vKmh = v * 3.6;
+        double vKmhPow = Math.pow(vKmh, 0.16);
+        return 13.12 + (0.6215 * ta) - (11.37 * vKmhPow) + (0.3965 * Math.pow(vKmh, 0.16) * ta);
+    }
+
+    /**
+     * 여름철 체감온도
+     *
+     * @param ta 기온
+     * @param rh 상대습도
+     */
+    private static double getSummerSensibleTemperature(double ta, double rh) {
+        double tw = getTw(ta, rh);
+        return -0.2442 + (0.55399 * tw) + (0.45535 * ta) - (0.0022 * Math.pow(tw, 2.0)) + (0.00278 * tw * ta) + 3.0;
+    }
+
+    /**
+     * 지금이 몇 월인지에 따라 여름 및 겨울 계산공식 적용
+     *
+     * @param ta 기온
+     * @param rh 상대습도
+     * @param v  10분 평균 풍속(Km/s), 그냥 풍속으로 계싼해도 무방함
+     * @return 체감온도
+     */
+    public static double getSensibleTemperature(double ta, double rh, double v) {
+        int season = getCurrentSeason();
+
+        if (ta <= 10 && v >= 1.3) {
+            return getWinterSensibleTemperature(ta, v);
+        }
+
+        if (season >= 5 && season <= 10) {
+            return getSummerSensibleTemperature(ta, rh);
+        }
+
+        return ta;
+    }
+
+
+    /**
+     * 습구온도 계산공식
+     *
+     * @param ta 온도
+     * @param rh 상대습도
+     */
+    private static double getTw(double ta, double rh) {
+        return ta * Math.atan(0.151977 * Math.pow(rh + 8.313659, 0.5)) +
+                Math.atan(ta + rh) - Math.atan(rh - 1.67633) +
+                (0.00391838 * Math.pow(rh, 1.5) * Math.atan(0.023101 * rh)) - 4.686035;
+    }
+
+    /**
+     * 현재 월수 출력
+     **/
+    private static int getCurrentSeason() {
+        return LocalDateTime.now().getMonthValue();
+    }
+}

--- a/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
+++ b/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
@@ -1,11 +1,10 @@
 package org.pknu.weather.config;
 
+import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-
-import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
@@ -18,6 +17,17 @@ public class AsyncConfig {
         executor.setMaxPoolSize(10);
         executor.setQueueCapacity(500);
         executor.setThreadNamePrefix("Executor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "threadPoolDeleteTaskExecutor")
+    public Executor getDeleteAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("DeleteExecutor-");
         executor.initialize();
         return executor;
     }

--- a/back/src/main/java/org/pknu/weather/domain/tag/RainTag.java
+++ b/back/src/main/java/org/pknu/weather/domain/tag/RainTag.java
@@ -1,11 +1,10 @@
 package org.pknu.weather.domain.tag;
 
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.pknu.weather.apiPayload.code.status.ErrorStatus;
 import org.pknu.weather.exception.GeneralException;
-
-import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
@@ -20,7 +19,7 @@ public enum RainTag implements EnumTag {
     LITTLE_STRONG("조금", "강함", 7),
     VERY_STRONG("매우", "강함", 8);
 
-    private final String Adverb;
+    private final String adverb;
     private final String text;
     private final Integer code;
 

--- a/back/src/main/java/org/pknu/weather/dto/WeatherQueryResult.java
+++ b/back/src/main/java/org/pknu/weather/dto/WeatherQueryResult.java
@@ -1,11 +1,10 @@
 package org.pknu.weather.dto;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 public class WeatherQueryResult {
     @Getter
@@ -16,5 +15,6 @@ public class WeatherQueryResult {
         LocalDateTime time;
         Integer rainProbability;
         Float rain;
+        Float snowCover;
     }
 }

--- a/back/src/main/java/org/pknu/weather/dto/converter/WeatherResponseConverter.java
+++ b/back/src/main/java/org/pknu/weather/dto/converter/WeatherResponseConverter.java
@@ -1,5 +1,8 @@
 package org.pknu.weather.dto.converter;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.pknu.weather.common.utils.TagUtils;
 import org.pknu.weather.domain.Location;
 import org.pknu.weather.domain.Member;
@@ -10,17 +13,13 @@ import org.pknu.weather.dto.TagDto;
 import org.pknu.weather.dto.WeatherQueryResult;
 import org.pknu.weather.dto.WeatherResponse;
 
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.List;
-
 public class WeatherResponseConverter {
 
     public static WeatherResponse.MainPageWeatherData toMainPageWeatherData(List<Weather> weatherList, Member member) {
         int max = Integer.MIN_VALUE;
         int min = Integer.MAX_VALUE;
 
-        for(Weather w : weatherList) {
+        for (Weather w : weatherList) {
             max = Math.max(max, w.getTemperature());
             min = Math.min(min, w.getTemperature());
         }
@@ -74,8 +73,9 @@ public class WeatherResponseConverter {
                 .build();
     }
 
-    public static WeatherResponse.SimpleRainInformation toSimpleRainInformation(WeatherQueryResult.SimpleRainInfo simpleRainInfo) {
-        if(simpleRainInfo == null) {
+    public static WeatherResponse.SimpleRainInformation toSimpleRainInformation(
+            WeatherQueryResult.SimpleRainInfo simpleRainInfo) {
+        if (simpleRainInfo.getRain() == 0 && simpleRainInfo.getSnowCover() == 0) {
             return WeatherResponse.SimpleRainInformation.builder()
                     .rainComment("오늘은 비소식이 없어요")
                     .addComment("")
@@ -85,21 +85,51 @@ public class WeatherResponseConverter {
         }
 
         long hours = Duration.between(simpleRainInfo.getTime(), LocalDateTime.now()).toHours();
-        String comment = "";
+        StringBuilder sb = new StringBuilder();
 
-        if(hours == 0) {
-            comment += "잠시후에 ";
+        if (hours == 0) {
+            sb.append("잠시 후에 ");
         } else {
-            comment += hours + "시간 뒤에 ";
+            sb.append(hours + "시간 뒤에 ");
         }
 
-        comment += "비 소식이 있어요.";
+        if (simpleRainInfo.getSnowCover() > 0) {
+            sb.append("눈 ");
+        } else {
+            sb.append("비 ");
+        }
+        sb.append("소식이 있어요.");
 
         return WeatherResponse.SimpleRainInformation.builder()
-                .rainComment(comment)
+                .rainComment(sb.toString())
                 .addComment("외출할 때 우산 꼭 챙기세요!")
                 .willRain(true)
                 .rainfallAmount(simpleRainInfo.getRain() + "mm")
                 .build();
     }
+
+//    private static String commentBuilder(SimpleRainInfo simpleRainInfo) {
+//        StringBuilder sb = new StringBuilder();
+//        if (simpleRainInfo == null) {
+//            sb.append()
+//        }
+//    }
+
+//    private static String checkRain(SimpleRainInfo simpleRainInfo) {
+//        LocalDateTime forecastTime = simpleRainInfo.getTime();
+//
+//        if (simpleRainInfo.getRain() > 0) {
+//            return forecastTimeCheck(forecastTime);
+//        }
+//
+//        return "오늘은 비소식이 없어요";
+//    }
+//
+//    private static String forecastTimeCheck(LocalDateTime forecastTime) {
+//        long hours = Duration.between(forecastTime, LocalDateTime.now()).toHours();
+//        if (hours == 0) {
+//            return "잠시 후에";
+//        }
+//        return hours + "시간 후에";
+//    }
 }

--- a/back/src/main/java/org/pknu/weather/repository/WeatherCustomRepositoryImpl.java
+++ b/back/src/main/java/org/pknu/weather/repository/WeatherCustomRepositoryImpl.java
@@ -1,17 +1,16 @@
 package org.pknu.weather.repository;
 
+import static org.pknu.weather.domain.QWeather.weather;
+
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.pknu.weather.common.formatter.DateTimeFormatter;
 import org.pknu.weather.common.utils.QueryUtils;
 import org.pknu.weather.domain.Location;
 import org.pknu.weather.domain.Weather;
 import org.pknu.weather.dto.WeatherQueryResult;
-
-import java.time.LocalDateTime;
-
-import static org.pknu.weather.domain.QWeather.weather;
 
 @RequiredArgsConstructor
 public class WeatherCustomRepositoryImpl implements WeatherCustomRepository {
@@ -30,22 +29,21 @@ public class WeatherCustomRepositoryImpl implements WeatherCustomRepository {
                 .select(Projections.constructor(WeatherQueryResult.SimpleRainInfo.class,
                         weather.presentationTime,
                         weather.rainProb,
-                        weather.rain
+                        weather.rain,
+                        weather.snowCover
                 ))
                 .from(weather)
                 .where(
                         QueryUtils.isSameLocation(locationEntity, weather),
                         QueryUtils.presentationTimeWithinLast24Hours(weather),
-                        weather.rain.gt(0)
+                        weather.rain.gt(0).or(weather.snowCover.gt(0))
                 )
                 .fetchFirst();
     }
 
     /**
-     * 해당 지역의 날씨가 갱신되었는지 확인하는 메서드
-     * ex.
-     * baseTime: 14:00, now: 14:00~16:59 true
-     * baseTime: 14:00, now: 17:00~      false
+     * 해당 지역의 날씨가 갱신되었는지 확인하는 메서드 ex. baseTime: 14:00, now: 14:00~16:59 true baseTime: 14:00, now: 17:00~      false
+     *
      * @param location
      * @return true = 갱신되었음(3시간 안지남), false = 갱신되지 않았음(3시간 지남)
      */

--- a/back/src/main/java/org/pknu/weather/service/MainPageService.java
+++ b/back/src/main/java/org/pknu/weather/service/MainPageService.java
@@ -1,5 +1,7 @@
 package org.pknu.weather.service;
 
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pknu.weather.domain.Location;
@@ -12,9 +14,6 @@ import org.pknu.weather.dto.converter.WeatherResponseConverter;
 import org.pknu.weather.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * 메인페이지에서 사용되는 API를 위한 서비스 즉, 화면에 맞춰진 로직을 관리한다. 해당 서비스는 서비스를 의존할 수 있다. 단 핵심 비즈니스 로직만 의존한다. 서비스를 참조하는 서비스를 한 곳으로 몰아서
@@ -35,6 +34,7 @@ public class MainPageService {
     /**
      * 메인 페이지에 날씨와 관련된 데이터를 반환한다. 만약 해당 지역의 날씨의 갱신 시간이 지났다면 갱신을 시도하고 반환한다. 만약 해당 지역의 날씨 정보가 없다면 저장하고 반환한다.
      *
+     * @param email
      * @return
      */
     @Transactional

--- a/back/src/test/java/org/pknu/weather/aop/AspectTest.java
+++ b/back/src/test/java/org/pknu/weather/aop/AspectTest.java
@@ -29,6 +29,8 @@
 //    @Autowired
 //    MemberRepository memberRepository;
 //
+//    @Autowired
+//    TestLocationCheckAspect testLocationCheckAspect;
 //
 //    public void aopTest() {
 //        // given

--- a/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
+++ b/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
@@ -37,29 +37,4 @@ class WeatherTest {
                 SensibleTemperatureUtils.getSensibleTemperature(weather.getTemperature(), weather.getHumidity(),
                         weather.getWindSpeed()));
     }
-
-    @Test
-    @Transactional
-    void test() {
-        for (int i = -30; i <= 0; i++) {
-            for (double w = 0.0f; w <= 30.0f; w += 0.1f) {
-                Weather weather = weatherRepository.save(Weather.builder()
-                        .temperature(i)
-                        .humidity(0)
-                        .windSpeed(w)
-                        .build());
-
-                em.flush();
-                em.clear();
-
-                weather = weatherRepository.findById(weather.getId()).get();
-
-                log.info("온도{}, 체감 {}, 습도 {}, 바람 {}",
-                        weather.getTemperature().toString(),
-                        weather.getSensibleTemperature().toString(),
-                        weather.getHumidity(),
-                        weather.getWindSpeed());
-            }
-        }
-    }
 }

--- a/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
+++ b/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
@@ -1,0 +1,65 @@
+package org.pknu.weather.domain;
+
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.pknu.weather.common.utils.SensibleTemperatureUtils;
+import org.pknu.weather.repository.WeatherRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Slf4j
+class WeatherTest {
+    @Autowired
+    WeatherRepository weatherRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    @Transactional
+    void weather_엔티티는_영속화_되기전_체감_온도를_갱신한다() {
+        // given
+        Weather weather = Weather.builder()
+                .temperature(14)
+                .humidity(50)
+                .windSpeed(1.5)
+                .build();
+
+        // when
+        weatherRepository.save(weather);
+
+        // then
+        Assertions.assertThat(weather.getSensibleTemperature()).isEqualTo(
+                SensibleTemperatureUtils.getSensibleTemperature(weather.getTemperature(), weather.getHumidity(),
+                        weather.getWindSpeed()));
+    }
+
+    @Test
+    @Transactional
+    void test() {
+        for (int i = -30; i <= 0; i++) {
+            for (double w = 0.0f; w <= 30.0f; w += 0.1f) {
+                Weather weather = weatherRepository.save(Weather.builder()
+                        .temperature(i)
+                        .humidity(0)
+                        .windSpeed(w)
+                        .build());
+
+                em.flush();
+                em.clear();
+
+                weather = weatherRepository.findById(weather.getId()).get();
+
+                log.info("온도{}, 체감 {}, 습도 {}, 바람 {}",
+                        weather.getTemperature().toString(),
+                        weather.getSensibleTemperature().toString(),
+                        weather.getHumidity(),
+                        weather.getWindSpeed());
+            }
+        }
+    }
+}

--- a/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
+++ b/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
@@ -21,7 +21,7 @@ class WeatherTest {
 
     @Test
     @Transactional
-    void weather_엔티티는_영속화_되기전_체감_온도를_갱신한다() {
+    void weather_엔티티는_영속화_되기전_체감_온도를_업데이트_한다() {
         // given
         Weather weather = Weather.builder()
                 .temperature(14)

--- a/back/src/test/java/org/pknu/weather/dto/converter/WeatherResponseConverterTest.java
+++ b/back/src/test/java/org/pknu/weather/dto/converter/WeatherResponseConverterTest.java
@@ -1,0 +1,39 @@
+package org.pknu.weather.dto.converter;
+
+import java.time.LocalDateTime;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.pknu.weather.dto.WeatherQueryResult.SimpleRainInfo;
+import org.pknu.weather.dto.WeatherResponse.SimpleRainInformation;
+
+class WeatherResponseConverterTest {
+
+    @ParameterizedTest
+    @MethodSource("source")
+    void 눈_비_간단_예보_변환_테스트(LocalDateTime time, Integer prob, Float rain, Float snow, String expect) {
+        // given
+        SimpleRainInfo simpleRainInfo = SimpleRainInfo.builder()
+                .time(time)
+                .rainProbability(prob)
+                .rain(rain)
+                .snowCover(snow)
+                .build();
+
+        // when
+        SimpleRainInformation simpleRainInformation = WeatherResponseConverter.toSimpleRainInformation(simpleRainInfo);
+
+        // then
+        Assertions.assertThat(simpleRainInformation.getRainComment()).contains(expect);
+    }
+
+    private static Stream<Arguments> source() {
+        return Stream.of(
+                Arguments.of(LocalDateTime.now().plusMinutes(30), 30, 1.0f, 0.0f, "비 소식이 있어요."),        // 비 올 때
+                Arguments.of(LocalDateTime.now().plusMinutes(30), 0, 0.0f, 0.0f, "오늘은 비소식이 없어요"),        // 비 안올 때
+                Arguments.of(LocalDateTime.now().plusMinutes(30), 30, 0.0f, 1.0f, "눈 소식이 있어요.")        // 눈 올 때
+        );
+    }
+}

--- a/back/src/test/java/org/pknu/weather/repository/LocationRepositoryTest.java
+++ b/back/src/test/java/org/pknu/weather/repository/LocationRepositoryTest.java
@@ -1,35 +1,23 @@
 package org.pknu.weather.repository;
 
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.PersistenceContext;
-import jakarta.transaction.Transactional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.pknu.weather.common.TestDataCreator;
-import org.pknu.weather.common.formatter.DateTimeFormatter;
-import org.pknu.weather.common.utils.GeometryUtils;
-import org.pknu.weather.config.QueryDslConfig;
-import org.pknu.weather.domain.Location;
-import org.pknu.weather.domain.Weather;
-import org.pknu.weather.validation.annotation.IsPositive;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import jakarta.transaction.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.pknu.weather.common.TestDataCreator;
+import org.pknu.weather.common.formatter.DateTimeFormatter;
+import org.pknu.weather.domain.Location;
+import org.pknu.weather.domain.Weather;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class LocationRepositoryTest {
@@ -47,12 +35,15 @@ class LocationRepositoryTest {
         List<Weather> weatherList = new ArrayList<>();
 
         // 어제, 오늘 날씨 추가
-        for(int i = 0; i <= 23; i++) {
+        for (int i = 0; i <= 23; i++) {
             Weather weather = Weather.builder()
                     .basetime(LocalDateTime.now())
                     .presentationTime(
                             DateTimeFormatter.formattedDateTime2LocalDateTime(DateTimeFormatter.getFormattedDate(),
-                            DateTimeFormatter.getFormattedTimeByOneHour(LocalTime.of(i, 0))))
+                                    DateTimeFormatter.getFormattedTimeByOneHour(LocalTime.of(i, 0))))
+                    .temperature(14)
+                    .humidity(50)
+                    .windSpeed(1.5)
                     .build();
 
             LocalDateTime now = LocalDateTime.now();
@@ -60,8 +51,12 @@ class LocationRepositoryTest {
                     .basetime(now)
                     .presentationTime(
                             DateTimeFormatter.formattedDateTime2LocalDateTime(
-                                    DateTimeFormatter.getFormattedDate(LocalDate.of(now.getYear(), now.getMonth(), now.getDayOfMonth() - 1)),
+                                    DateTimeFormatter.getFormattedDate(
+                                            LocalDate.of(now.getYear(), now.getMonth(), now.getDayOfMonth() - 1)),
                                     DateTimeFormatter.getFormattedTimeByOneHour(LocalTime.of(i, 0))))
+                    .temperature(14)
+                    .humidity(50)
+                    .windSpeed(1.5)
                     .build();
 
             weather.addLocation(location);

--- a/back/src/test/java/org/pknu/weather/repository/WeatherRepositoryTest.java
+++ b/back/src/test/java/org/pknu/weather/repository/WeatherRepositoryTest.java
@@ -1,23 +1,20 @@
 package org.pknu.weather.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.pknu.weather.common.TestDataCreator;
-import org.pknu.weather.common.TestGlobalParams;
 import org.pknu.weather.common.formatter.DateTimeFormatter;
-import org.pknu.weather.common.utils.GeometryUtils;
 import org.pknu.weather.domain.Location;
 import org.pknu.weather.domain.Weather;
 import org.pknu.weather.dto.WeatherQueryResult;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 
 @SpringBootTest
@@ -47,6 +44,9 @@ class WeatherRepositoryTest {
                 .basetime(now.minusHours(3))
                 .presentationTime(now.plusHours(1))
                 .location(createLocation())
+                .temperature(14)
+                .humidity(50)
+                .windSpeed(1.5)
                 .build();
 
         Weather weatherEntity = weatherRepository.save(weather);
@@ -69,6 +69,9 @@ class WeatherRepositoryTest {
                 .basetime(baseTime)
                 .presentationTime(TestDataCreator.getLocalDateTimePlusHours(1))
                 .location(createLocation())
+                .temperature(14)
+                .humidity(50)
+                .windSpeed(1.5)
                 .build();
 
         Weather weatherEntity = weatherRepository.save(weather);
@@ -104,6 +107,9 @@ class WeatherRepositoryTest {
                 .basetime(baseTime)
                 .presentationTime(TestDataCreator.getLocalDateTimePlusHours(1))
                 .location(createLocation())
+                .temperature(14)
+                .humidity(50)
+                .windSpeed(1.5)
                 .build();
 
         Weather weatherEntity = weatherRepository.save(weather);
@@ -127,6 +133,9 @@ class WeatherRepositoryTest {
                 .location(location)
                 .rain(1.0F)
                 .rainProb(10)
+                .temperature(14)
+                .humidity(50)
+                .windSpeed(1.5)
                 .build();
 
         weatherRepository.save(weather);
@@ -151,6 +160,9 @@ class WeatherRepositoryTest {
                 .location(location)
                 .rain(0.0F)
                 .rainProb(0)
+                .temperature(14)
+                .humidity(50)
+                .windSpeed(1.5)
                 .build();
 
         weatherRepository.save(weather);

--- a/back/src/test/java/org/pknu/weather/service/MainPageServiceTest.java
+++ b/back/src/test/java/org/pknu/weather/service/MainPageServiceTest.java
@@ -1,88 +1,41 @@
-//package org.pknu.weather.service;
-//
-//
-//import jakarta.transaction.Transactional;
-//import lombok.extern.slf4j.Slf4j;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.pknu.weather.common.utils.GeometryUtils;
-//import org.pknu.weather.domain.Location;
-//import org.pknu.weather.domain.Member;
-//import org.pknu.weather.domain.Weather;
-//import org.pknu.weather.domain.common.Sensitivity;
-//import org.pknu.weather.dto.WeatherResponse;
-//import org.pknu.weather.repository.LocationRepository;
-//import org.pknu.weather.repository.MemberRepository;
-//import org.pknu.weather.repository.WeatherRepository;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//import java.util.List;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//
-//
-//@SpringBootTest
-//@Slf4j
-//class MainPageServiceTest {
-//    @Autowired
-//    MainPageService mainPageService;
-//
-//    @Autowired
-//    WeatherService weatherService;
-//
-//    @Autowired
-//    LocationRepository locationRepository;
-//
-//    @Autowired
-//    MemberRepository memberRepository;
-//
-//    @Autowired
-//    WeatherRepository weatherRepository;
-//
-//    private final double LATITUDE = 35.1845361111111;
-//    private final double LONGITUDE = 128.989688888888;
-//    private final String VILLAGE_NAME = "사상구 모라동";
-//
-//    @BeforeEach
-//    void init() {
-//        Location location = Location.builder()
-//                .point(GeometryUtils.getPoint(LATITUDE, LONGITUDE))
-//                .city("사상구")
-//                .province("province")
-//                .street("모라동")
-//                .latitude(LATITUDE)
-//                .longitude(LONGITUDE)
-//                .build();
-//
-//        Member member = Member.builder()
-//                .location(location)
-//                .email("email@naver.com")
-//                .nickname("nickname")
-//                .sensitivity(Sensitivity.NONE)
-//                .build();
-//
-//        location = locationRepository.save(location);
-//        member = memberRepository.save(member);
-//        weatherService.saveWeathers(location);
-//    }
-//
-//    @Test
-//    @DisplayName("메인 페이지의 날씨 예보와 관련된 정보를 불러오는 API 통합 테스트")
-//    @Transactional
-//    void mainPageWeatherApiTest(){
-//        // given
-//        Member member = memberRepository.findAll().get(0);
-//        Location location = member.getLocation();
-//        List<Weather> weatherList = weatherService.getWeathers(location);
-//
-//        // when
-//        WeatherResponse.MainPageWeatherData weatherInfo = mainPageService.getWeatherInfo(member.getId());
-//
-//        // then
-//        assertThat(weatherInfo.getCurrentTmp()).isEqualTo(weatherList.get(0).getTemperature());
-//        assertThat(weatherInfo.getWeatherPerHourList().size()).isGreaterThanOrEqualTo(21);  // 3시간 간격으로 예보를 발표하기 때문에 22 ~ 24개의 예보
-//        assertThat(weatherInfo.getCurrentSkyType()).isEqualTo(weatherList.get(0).getSkyType());
-//    }
-//}
+package org.pknu.weather.service;
+
+
+import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.pknu.weather.repository.LocationRepository;
+import org.pknu.weather.repository.MemberRepository;
+import org.pknu.weather.repository.WeatherRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+@Slf4j
+class MainPageServiceTest {
+    @Autowired
+    MainPageService mainPageService;
+
+    @Autowired
+    WeatherService weatherService;
+
+    @Autowired
+    LocationRepository locationRepository;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    WeatherRepository weatherRepository;
+
+    @Test
+    @Transactional
+    void 사용자_지역이_없을_때_테스트() {
+        // given
+
+        // when
+
+        // then
+    }
+}

--- a/back/src/test/resources/application.yml
+++ b/back/src/test/resources/application.yml
@@ -15,7 +15,7 @@ spring:
         use_sql_comments: true
         default_batch_fetch_size: 500
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     open-in-view: false   # osiv 설정
   jwt:
     key: ${JWT_KEY}
@@ -25,7 +25,7 @@ spring:
   weather:
     key: ${METEOROLOGICAL_ADMIN_KEY}
   profiles:
-    active: local
+    active: default
   servlet:
     multipart:
       enabled: true

--- a/back/src/test/resources/application.yml
+++ b/back/src/test/resources/application.yml
@@ -11,12 +11,11 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
-        show_sql: true
         format_sql: true
         use_sql_comments: true
         default_batch_fetch_size: 500
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     open-in-view: false   # osiv 설정
   jwt:
     key: ${JWT_KEY}
@@ -26,7 +25,7 @@ spring:
   weather:
     key: ${METEOROLOGICAL_ADMIN_KEY}
   profiles:
-    active: default
+    active: local
   servlet:
     multipart:
       enabled: true


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #187 
- 체감 온도 계산 공식 추가 및 Weather 테이블에 컬럼 추가
    - 여름 체감 온도 공식은 25도 이상일 때 동작합니다.
    - 겨울 체감 온도 공식은 10도 이하 && 풍속 1.3m/s 이상일 때 동작합니다.
- AOP 포인트컷 대상을 수정
- 체감 온도 계산 test 추가
- delete 용 스레드풀 설정
- 강수 간단 정보 API -> 눈이 내리는 경우에는 강수량이 아닌 적설량으로 표기되도록 수정

### PR 설명
- 
