### PR TITLE
[BE/Fix] 도메인에 멤버 탈퇴 시 연관된 게시물과 좋아요도 같이 삭제하도록 수정

### DIFF
--- a/back/src/main/java/org/pknu/weather/domain/Member.java
+++ b/back/src/main/java/org/pknu/weather/domain/Member.java
@@ -41,9 +41,13 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "location_id")
     private Location location;
 
-    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @Builder.Default
     private List<Post> postList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @Builder.Default
+    private List<Recommendation> recommendationList = new ArrayList<>();
 
     public void changeLocation(Location location){
         this.location = location;

--- a/back/src/main/java/org/pknu/weather/domain/Post.java
+++ b/back/src/main/java/org/pknu/weather/domain/Post.java
@@ -35,7 +35,7 @@ public class Post extends BaseEntity {
     private Member member;
 
     @Builder.Default
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<Recommendation> recommendationList = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #191 

### PR 설명
- 멤버 탈퇴 시, 작성한 게시물과 좋아요가 있다면 같이 삭제하도록 도메인의 멤버 엔티티를 수정했습니다.
