### PR TITLE
[BE/Config] 모니터링 툴 구축을 위한 라이브러리와 설정 추가

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -79,6 +79,8 @@ dependencies {
 	implementation 'org.locationtech.proj4j:proj4j:1.3.0'
 	implementation 'org.locationtech.proj4j:proj4j-epsg:1.3.0'
 
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 
 }
 tasks.named('test') {

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -56,6 +56,7 @@ management:
   endpoint:
     health:
       show-details: always
+  endpoints:
     web:
       exposure:
         include: '*'

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -56,6 +56,10 @@ management:
   endpoint:
     health:
       show-details: always
+    web:
+      exposure:
+        include: '*'
+
 cloud:
   aws:
     credentials:
@@ -67,3 +71,8 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #221 

### PR 설명
- 어플리케이션의 모니터링을 위해 프로메테우스와 그라파나를 도입
- Micrometer와 Prometheus를 통합하기 위한 라이브러리를 gradle에 추가
  - Micrometer
     - JVM 기반 애플리케이션에서 다양한 메트릭(ex. CPU 사용량, 메모리 소비, HTTP 요청 등)을 수집하고 관리하기 위한 라이브러리
     - 독립적인 메트릭 수집 API를 제공하며, 다양한 모니터링 시스템(Prometheus, Datadog, New Relic 등)과 통합 가능