### PR TITLE
[BE/FIX]: 회원 탈퇴 순서 변경 및 인증 정보 null 문제 해결

### DIFF
--- a/back/src/main/java/org/pknu/weather/controller/MemberControllerV1.java
+++ b/back/src/main/java/org/pknu/weather/controller/MemberControllerV1.java
@@ -60,8 +60,17 @@ public class MemberControllerV1 {
                                             @RequestBody(required = false) Map<String, String> authInfo) {
 
         Map<String, Object> memberInfo = getMemberInfoFromAuth(authorization);
-        memberService.deleteMember(memberInfo, authInfo.get("authenticationCode"));
+
+        addAuthCodeToMemberInfo(authInfo, memberInfo);
+
+        memberService.deleteMember(memberInfo);
 
         return ApiResponse.onSuccess();
+    }
+
+    private void addAuthCodeToMemberInfo(Map<String, String> authInfo, Map<String, Object> memberInfo) {
+        if (authInfo != null && authInfo.get("authenticationCode") != null) {
+            memberInfo.put("authenticationCode", authInfo.get("authenticationCode"));
+        }
     }
 }

--- a/back/src/main/java/org/pknu/weather/service/MemberService.java
+++ b/back/src/main/java/org/pknu/weather/service/MemberService.java
@@ -86,16 +86,21 @@ public class MemberService {
     }
 
     @Transactional
-    public void deleteMember(Map<String, Object> memberInfo, String authenticationCode){
+    public void deleteMember(Map<String, Object> memberInfo){
+
+        deleteMemberFromDB(memberInfo);
 
         String type = String.valueOf(memberInfo.get("type"));
 
         if (type.equals("kakao")) {
             kakaoUnlinker.unlinkUser(String.valueOf(memberInfo.get("kakaoId")));
         } else if (type.equals("apple")) {
-            appleUnlinker.unlinkUser(authenticationCode);
+            appleUnlinker.unlinkUser(String.valueOf(memberInfo.get("authenticationCode")));
         }
 
+    }
+
+    private void deleteMemberFromDB(Map<String, Object> memberInfo) {
         Member member = memberRepository.findMemberByEmail(String.valueOf(memberInfo.get("email")))
                 .orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
 


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #235 

### PR 설명
- 멤버의 정보를 DB에서 삭제 후 외부 API서버에 회원 탈퇴 요청
- 회원 탈퇴 시 인증 정보를 받지 않은 경우 생기는  null 문제 해결
