### PR TITLE
[BE/FIX]: 멤버와 로케이션 관계 재설정 및 테스트 주석 해제

### DIFF
--- a/back/src/main/java/org/pknu/weather/domain/Member.java
+++ b/back/src/main/java/org/pknu/weather/domain/Member.java
@@ -37,7 +37,7 @@ public class Member extends BaseEntity {
     @ColumnDefault("'basic.png'")
     private String profileImageName;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "location_id")
     private Location location;
 

--- a/back/src/test/java/org/pknu/weather/repository/PostCustomRepositoryTest.java
+++ b/back/src/test/java/org/pknu/weather/repository/PostCustomRepositoryTest.java
@@ -1,5 +1,5 @@
 package org.pknu.weather.repository;
-/*
+
 import jakarta.persistence.EntityManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -62,4 +62,4 @@ class PostCustomRepositoryTest {
     }
 }
 
- */
+ 


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #235 

### PR 설명
- 멤버와 로케이션 관계를 cascade.persist로 수정하니 문제가 발생했던 테스트가 해결되었습니다.
