### PR TITLE
[FE/Fix] 플랫폼별 상태 관리 로직 분리

### DIFF
--- a/front/android/app/build.gradle
+++ b/front/android/app/build.gradle
@@ -82,8 +82,8 @@ android {
         applicationId "com.weather2"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4
-        versionName "1.0.4"
+        versionCode 5
+        versionName "1.0.5"
         manifestPlaceholders = [kakaoAppKey: "53650279ac97bd9bde779eba3f9f2499"]
     }
     signingConfigs {

--- a/front/src/api/api.js
+++ b/front/src/api/api.js
@@ -486,8 +486,10 @@ export const fetchMemberInfo = async accessToken => {
     });
 
     const result = await response.json();
+    console.log('Fetch memeber info api:', result);
+
     if (result.isSuccess) {
-      return result.result;
+      return result;
     } else {
       throw new Error(result.message);
     }

--- a/front/src/screens/MyScreen.js
+++ b/front/src/screens/MyScreen.js
@@ -63,15 +63,15 @@ const MyScreen = ({
       const memberInfo = await fetchMemberInfo(accessToken);
       console.log('Fetched member info:', memberInfo);
       if (
-        memberInfo.profileImage &&
-        memberInfo.profileImage.startsWith('http')
+        memberInfo.result.profileImage &&
+        memberInfo.result.profileImage.startsWith('http')
       ) {
-        setProfileImage({uri: memberInfo.profileImage});
+        setProfileImage({uri: memberInfo.result.profileImage});
       } else {
         setProfileImage(profilePlaceholder);
       }
-      setNickname(memberInfo.nickname || '닉네임');
-      setEmail(memberInfo.email || 'example@email.com');
+      setNickname(memberInfo.result.nickname || '닉네임');
+      setEmail(memberInfo.result.email || 'example@email.com');
       setLoading(false);
     } catch (error) {
       console.error('회원 정보 불러오는 중 오류 발생:', error);
@@ -178,7 +178,7 @@ const MyScreen = ({
           console.error('Apple authentication error:', error);
           Alert.alert(
             'Apple 로그인 실패',
-            '회원 탈퇴를 원하시면 로그인이 필요합니다.',
+            '회원 탈퇴를 위해서는 로그인이 필요합니다.',
           );
           return;
         }

--- a/front/src/screens/PostCreationScreen.js
+++ b/front/src/screens/PostCreationScreen.js
@@ -46,10 +46,10 @@ const PostCreationScreen = ({navigation, accessToken, route}) => {
     const loadMemberInfo = async () => {
       try {
         const memberInfo = await fetchMemberInfo(accessToken);
-        setNickname(memberInfo.nickname || '사용자');
+        setNickname(memberInfo.result.nickname || '사용자');
         setProfileImage(
-          memberInfo.profileImage?.startsWith('http')
-            ? {uri: memberInfo.profileImage}
+          memberInfo.result.profileImage?.startsWith('http')
+            ? {uri: memberInfo.result.profileImage}
             : require('../../assets/images/profile.png'),
         );
       } catch (error) {

--- a/front/src/screens/ProfileScreen.js
+++ b/front/src/screens/ProfileScreen.js
@@ -29,14 +29,14 @@ const ProfileScreen = ({accessToken, navigation, route}) => {
       try {
         const memberInfo = await fetchMemberInfo(accessToken);
         if (
-          memberInfo.profileImage &&
-          memberInfo.profileImage.startsWith('http')
+          memberInfo.result.profileImage &&
+          memberInfo.result.profileImage.startsWith('http')
         ) {
-          setProfileImage({uri: memberInfo.profileImage});
+          setProfileImage({uri: memberInfo.result.profileImage});
         }
-        setNickname(memberInfo.nickname || '닉네임');
-        setEmail(memberInfo.email || 'example@email.com');
-        setSelectedType(memberInfo.sensitivity.toLowerCase());
+        setNickname(memberInfo.result.nickname || '닉네임');
+        setEmail(memberInfo.result.email || 'example@email.com');
+        setSelectedType(memberInfo.result.sensitivity.toLowerCase());
         setLoading(false);
       } catch (error) {
         console.error('Error fetching profile data:', error);

--- a/front/src/screens/RegisterProfileScreen.js
+++ b/front/src/screens/RegisterProfileScreen.js
@@ -75,11 +75,6 @@ const RegisterProfileScreen = ({
       return;
     }
 
-    if (!profileImage) {
-      Alert.alert('프로필 이미지 설정', '프로필 이미지를 선택해주세요.');
-      return;
-    }
-
     if (!selectedType) {
       Alert.alert('유형 선택', '날씨 체감 유형을 선택해주세요.');
       return;
@@ -133,6 +128,7 @@ const RegisterProfileScreen = ({
     } catch (error) {
       console.error('프로필 저장 오류:', error);
       Alert.alert('프로필 저장 실패', error.message);
+    } finally {
       setLoading(false);
     }
   };


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- 애플 및 카카오 사용자 검증 로직 분리
- fetchMemberInfo 호출을 통해 사용자 정보를 검증하도록 수정하여 불필요한 네트워크 요청 감소
- 공통 상태 관리 및 화면 전환 로직 일관성 유지
- 자동 로그인 기능 개선
  - 토큰 갱신 실패 또는 사용자 정보 확인 실패 시 로그인 상태 초기화

### PR 설명
- 
