### PR TITLE
[BE/Fix]: 회원정보 수정 API에서 이미지 파일이 없을 시 nullexception이 일어나지 않도록 수정

### DIFF
--- a/back/src/main/java/org/pknu/weather/filter/TokenCheckFilter.java
+++ b/back/src/main/java/org/pknu/weather/filter/TokenCheckFilter.java
@@ -35,12 +35,12 @@ public class TokenCheckFilter extends OncePerRequestFilter {
 
          log.debug("Token Check Filter............................");
 
-        try{
+        try {
             validateAccessToken(request);
 
             filterChain.doFilter(request,response);
 
-        }catch (TokenException TokenException){
+        } catch (TokenException TokenException){
             TokenException.sendResponseError(response);
         }
     }

--- a/back/src/main/java/org/pknu/weather/service/MemberService.java
+++ b/back/src/main/java/org/pknu/weather/service/MemberService.java
@@ -69,7 +69,8 @@ public class MemberService {
 
         MultipartFile profileImg = memberJoinDTO.getProfileImg();
 
-        if (!profileImg.isEmpty() && profileImg.getContentType().startsWith("image")) {
+
+        if (isProfileImgValid(profileImg)) {
             uploadProfileImageToS3(memberJoinDTO, profileImg);
             removeExProfileImage(member);
         }
@@ -78,6 +79,12 @@ public class MemberService {
         Member savedMember = checkNicknameAndSave(member);
 
         return toMemberResponseDTO(savedMember);
+    }
+
+    private boolean isProfileImgValid(MultipartFile profileImg) {
+        return profileImg != null
+                && !profileImg.isEmpty()
+                && profileImg.getContentType().startsWith("image");
     }
 
     /**


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #277 

### PR 설명
- 회원정보 수정 API에서 이미지를 전송하지 않고 다른 정보들만 입력 시 null exception으로 문제 발생
- 이미지 파일을 전송하지 않더라도 다른 정보들이 반영될 수 있도록 수정했습니다.
