### PR TITLE
bug: 미세먼지 조회 시 지역이 제대로 설정되지 않는 문제 해결

### DIFF
--- a/back/src/main/java/org/pknu/weather/feignClient/utils/ExtraWeatherApiUtils.java
+++ b/back/src/main/java/org/pknu/weather/feignClient/utils/ExtraWeatherApiUtils.java
@@ -201,6 +201,7 @@ public class ExtraWeatherApiUtils {
             return result.getResponse().getBody().getItems().get(0);
         else
             throw new GeneralException(ErrorStatus._API_SERVER_ERROR);
+
     }
 
 

--- a/back/src/main/java/org/pknu/weather/repository/MemberRepository.java
+++ b/back/src/main/java/org/pknu/weather/repository/MemberRepository.java
@@ -28,6 +28,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Member findByEmail(String email);
 
     @EntityGraph(attributePaths = {"location"})
+    Optional<Member> findMemberWithLocationByEmail(@Param("email") String email);
+
+
+    @EntityGraph(attributePaths = {"location"})
     default Member safeFindByEmail(String email) {
         Member member = findByEmail(email);
 


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #344 

### PR 설명
- 미세먼지 조회 시, 회원의 장소를 조회하지 못하는 부분을 수정했습니다.
- 람다식에서는 lazy loading이 적용되지 않아 문제가 발생했습니다.
- @EntityGraph를 통해 멤버와 지역을 동시에 로딩하도록 수정했습니다.