### PR TITLE
[FE/Config] Xcode 16 업데이트 및 iOS 18 SDK 대응

### DIFF
--- a/front/android/app/build.gradle
+++ b/front/android/app/build.gradle
@@ -82,8 +82,8 @@ android {
         applicationId "com.weather2"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 10
-        versionName "1.0.10"
+        versionCode 11
+        versionName "1.0.11"
         manifestPlaceholders = [kakaoAppKey: "53650279ac97bd9bde779eba3f9f2499"]
     }
     signingConfigs {

--- a/front/ios/Weather2.xcodeproj/project.pbxproj
+++ b/front/ios/Weather2.xcodeproj/project.pbxproj
@@ -494,7 +494,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -523,7 +523,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.2;
+				MARKETING_VERSION = 1.0.3;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",


### PR DESCRIPTION
### PR 요약 혹은 이슈 번호(링크)
- #365 
- 2025년 4월 24일 이후에는 iOS 18 SDK로 빌드해야하므로 Xcode 16으로 업데이트가 필요하다
<img width="872" alt="스크린샷 2025-03-20 오후 12 11 06" src="https://github.com/user-attachments/assets/89050536-02b2-4450-82de-9b6a4f6bebaa" />


### PR 설명
- 
