### PR TITLE
[Fe/Fix] API 중복 호출 현상 해결

### DIFF
--- a/front/src/components/AirQuality.js
+++ b/front/src/components/AirQuality.js
@@ -5,7 +5,7 @@ import {fetchExtraWeatherInfo} from '../api/api';
 
 const {width} = Dimensions.get('window');
 
-const AirQuality = ({accessToken, refreshing}) => {
+const AirQuality = ({accessToken, weatherData}) => {
   const [extraWeatherInfo, setExtraWeatherInfo] = useState({
     pm25Grade: 0,
     pm10Grade: 0,
@@ -14,7 +14,7 @@ const AirQuality = ({accessToken, refreshing}) => {
     pm10Value: null,
     pm25Value: null,
   });
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   const getGradeText = grade => {
     if (grade === 0) return '좋음';
@@ -62,23 +62,25 @@ const AirQuality = ({accessToken, refreshing}) => {
     }
   };
 
-  useEffect(() => {
-    const loadExtraWeatherInfo = async () => {
-      try {
-        const data = await fetchExtraWeatherInfo(accessToken);
-        // console.log('Fetched extra weather info:', data);
-        setExtraWeatherInfo(data);
-      } catch (error) {
-        console.error('Error fetching extra weather info:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
+  const loadExtraWeatherInfo = async () => {
+    if (loading || !accessToken) return;
+    setLoading(true);
+    try {
+      const data = await fetchExtraWeatherInfo(accessToken);
+      // console.log('Fetched extra weather info:', data);
+      setExtraWeatherInfo(data);
+    } catch (error) {
+      console.error('Error fetching extra weather info:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    if (accessToken) {
+  useEffect(() => {
+    if (weatherData) {
       loadExtraWeatherInfo();
     }
-  }, [accessToken, refreshing]);
+  }, [weatherData]);
 
   return (
     <View style={styles.container}>


### PR DESCRIPTION
### 이슈 번호(링크)
`ex. Closes #123`

Closes #401 

### PR 요약 혹은 설명
- AirQuality.js에서 extraWeatherInfo API 중복 호출 문제 해결

- useEffect 의존성 수정: [accessToken, refreshing] → [weatherData]

- loading 상태로 중복 요청 방지

- 호출 시점 조정으로 불필요한 API 요청 제거


