### PR TITLE
[BE/Refactor] 동시에 요청이 발생했을 때 날씨 데이터 생성/갱신 과정에서 데드락이 발생하던 현상 해결 및 리팩토링

### DIFF
--- a/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
+++ b/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
@@ -1,7 +1,6 @@
 package org.pknu.weather.config;
 
 import java.util.concurrent.Executor;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -12,7 +11,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class AsyncConfig {
 
     @Bean(name = "WeatherCUDExecutor")
-    @ConditionalOnMissingBean(name = "WeatherCUDExecutor")
     public Executor getWeatherAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);
@@ -24,7 +22,6 @@ public class AsyncConfig {
     }
 
     @Bean(name = "ExpCUDExecutor")
-    @ConditionalOnMissingBean(name = "ExpCUDExecutor")
     public Executor getExpAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(1);

--- a/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
+++ b/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package org.pknu.weather.config;
 
 import java.util.concurrent.Executor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -11,6 +12,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class AsyncConfig {
 
     @Bean(name = "WeatherCUDExecutor")
+    @ConditionalOnMissingBean(name = "WeatherCUDExecutor")
     public Executor getWeatherAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);
@@ -22,6 +24,7 @@ public class AsyncConfig {
     }
 
     @Bean(name = "ExpCUDExecutor")
+    @ConditionalOnMissingBean(name = "ExpCUDExecutor")
     public Executor getExpAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(1);

--- a/back/src/main/java/org/pknu/weather/controller/MainPageControllerV1.java
+++ b/back/src/main/java/org/pknu/weather/controller/MainPageControllerV1.java
@@ -35,11 +35,7 @@ public class MainPageControllerV1 {
             @RequestParam(required = false) Long locationId) {
 
         String email = TokenConverter.getEmailByToken(authorization);
-        long start = System.currentTimeMillis();
-
         WeatherResponse.MainPageWeatherData weatherInfo = mainPageService.getWeatherInfo(email, locationId);
-        long afterMinMax = System.currentTimeMillis();
-        log.info("getWeatherInfo 시간: {}ms", (afterMinMax - start));
 
         return ApiResponse.onSuccess(weatherInfo);
     }

--- a/back/src/main/java/org/pknu/weather/domain/Location.java
+++ b/back/src/main/java/org/pknu/weather/domain/Location.java
@@ -1,21 +1,11 @@
 package org.pknu.weather.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
+import lombok.*;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -25,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class Location extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "location_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/Member.java
+++ b/back/src/main/java/org/pknu/weather/domain/Member.java
@@ -1,27 +1,7 @@
 package org.pknu.weather.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
@@ -30,6 +10,10 @@ import org.pknu.weather.domain.common.Sensitivity;
 import org.pknu.weather.domain.exp.Level;
 import org.pknu.weather.dto.MemberJoinDTO;
 import org.pknu.weather.exception.GeneralException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Entity(name = "member")
 @Getter
@@ -41,7 +25,7 @@ import org.pknu.weather.exception.GeneralException;
 public class Member extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/MemberTerms.java
+++ b/back/src/main/java/org/pknu/weather/domain/MemberTerms.java
@@ -11,7 +11,7 @@ import lombok.*;
 public class MemberTerms {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_terms_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/Post.java
+++ b/back/src/main/java/org/pknu/weather/domain/Post.java
@@ -1,27 +1,12 @@
 package org.pknu.weather.domain;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
-import java.util.ArrayList;
-import java.util.List;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.pknu.weather.domain.common.PostType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -31,7 +16,7 @@ import org.pknu.weather.domain.common.PostType;
 public class Post extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/Recommendation.java
+++ b/back/src/main/java/org/pknu/weather/domain/Recommendation.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 public class Recommendation extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "recommendation_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/Tag.java
+++ b/back/src/main/java/org/pknu/weather/domain/Tag.java
@@ -29,7 +29,7 @@ import org.pknu.weather.domain.tag.WindTag;
 public class Tag extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "tag_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/Terms.java
+++ b/back/src/main/java/org/pknu/weather/domain/Terms.java
@@ -12,7 +12,7 @@ import org.pknu.weather.domain.common.TermsType;
 public class Terms {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "terms_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/Weather.java
+++ b/back/src/main/java/org/pknu/weather/domain/Weather.java
@@ -1,13 +1,25 @@
 package org.pknu.weather.domain;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.pknu.weather.common.utils.SensibleTemperatureUtils;
 import org.pknu.weather.domain.common.RainType;
 import org.pknu.weather.domain.common.SkyType;
 import org.pknu.weather.dto.WeatherApiResponse;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -17,7 +29,7 @@ import java.time.LocalDateTime;
 public class Weather extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "weather_id")
     private Long id;
 

--- a/back/src/main/java/org/pknu/weather/domain/Weather.java
+++ b/back/src/main/java/org/pknu/weather/domain/Weather.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -26,12 +28,20 @@ import org.pknu.weather.dto.WeatherApiResponse;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Table(name = "weather", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "location_id_presentation_time_unique",
+                columnNames = {"location_id", "presentation_time"}
+        )})
 public class Weather extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "weather_id")
     private Long id;
+
+    @Column(name = "presentation_time", nullable = false)
+    private LocalDateTime presentationTime;
 
     private LocalDateTime basetime;
 
@@ -57,7 +67,6 @@ public class Weather extends BaseEntity {
 
     private SkyType skyType;
 
-    private LocalDateTime presentationTime;
 
     @PrePersist
     @PreUpdate

--- a/back/src/main/java/org/pknu/weather/repository/WeatherCustomRepository.java
+++ b/back/src/main/java/org/pknu/weather/repository/WeatherCustomRepository.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.pknu.weather.domain.Location;
 import org.pknu.weather.domain.Weather;
 import org.pknu.weather.dto.WeatherQueryResult;
@@ -22,4 +21,8 @@ public interface WeatherCustomRepository {
     Map<LocalDateTime, Weather> findAllByLocationAfterNow(Location location);
 
     List<WeatherSummaryDTO> findWeatherSummary(Set<Long> locationIds);
+
+    void batchUpdate(List<Weather> weatherList, Location location);
+
+    void batchSave(List<Weather> newForecast, Location location);
 }

--- a/back/src/main/java/org/pknu/weather/service/MainPageService.java
+++ b/back/src/main/java/org/pknu/weather/service/MainPageService.java
@@ -1,6 +1,5 @@
 package org.pknu.weather.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pknu.weather.domain.Location;
@@ -15,6 +14,8 @@ import org.pknu.weather.repository.LocationRepository;
 import org.pknu.weather.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 메인페이지에서 사용되는 API를 위한 서비스 즉, 화면에 맞춰진 로직을 관리한다. 해당 서비스는 서비스를 의존할 수 있다. 단 핵심 비즈니스 로직만 의존한다. 서비스를 참조하는 서비스를 한 곳으로 몰아서
@@ -63,7 +64,7 @@ public class MainPageService {
     private List<Weather> createWeatherIfRequired(Location location, Member member) {
         if (!weatherQueryService.weatherHasBeenCreated(location)) {
             List<Weather> weatherList = weatherFeignClientUtils.getVillageShortTermForecast(location);
-            weatherService.bulkSaveWeathersAsync(location.getId(), weatherList);
+            weatherService.saveWeathersAsync(location.getId(), weatherList);
             return weatherList;
         }
         return null;

--- a/back/src/main/java/org/pknu/weather/service/MainPageService.java
+++ b/back/src/main/java/org/pknu/weather/service/MainPageService.java
@@ -1,5 +1,6 @@
 package org.pknu.weather.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pknu.weather.domain.Location;
@@ -14,8 +15,6 @@ import org.pknu.weather.repository.LocationRepository;
 import org.pknu.weather.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 /**
  * 메인페이지에서 사용되는 API를 위한 서비스 즉, 화면에 맞춰진 로직을 관리한다. 해당 서비스는 서비스를 의존할 수 있다. 단 핵심 비즈니스 로직만 의존한다. 서비스를 참조하는 서비스를 한 곳으로 몰아서
@@ -64,7 +63,7 @@ public class MainPageService {
     private List<Weather> createWeatherIfRequired(Location location, Member member) {
         if (!weatherQueryService.weatherHasBeenCreated(location)) {
             List<Weather> weatherList = weatherFeignClientUtils.getVillageShortTermForecast(location);
-            weatherService.saveWeathersAsync(location.getId(), weatherList);
+            weatherService.bulkSaveWeathersAsync(location.getId(), weatherList);
             return weatherList;
         }
         return null;
@@ -72,7 +71,7 @@ public class MainPageService {
 
     private void updateWeatherIfRequired(Location location) {
         if (!weatherQueryService.weatherHasBeenUpdated(location)) {
-            weatherService.updateWeathersAsync(location.getId());
+            weatherService.bulkUpdateWeathersAsync(location.getId());
         }
     }
 

--- a/back/src/main/java/org/pknu/weather/service/MainPageService.java
+++ b/back/src/main/java/org/pknu/weather/service/MainPageService.java
@@ -41,28 +41,38 @@ public class MainPageService {
      */
     public WeatherResponse.MainPageWeatherData getWeatherInfo(String email, Long locationId) {
         Member member = memberRepository.safeFindByEmail(email);
+        Location location = resolveLocation(member, locationId);
 
-        Location location;
-        if (locationId != null) {
-            location = locationRepository.safeFindById(locationId);
-        } else {
-            location = member.getLocation();
-        }
-
-        // 해당 지역에 날씨 예보가 있는지 없는지 체크
-        if (!weatherQueryService.weatherHasBeenCreated(location)) {
-            List<Weather> weatherList = weatherFeignClientUtils.getVillageShortTermForecast(location);
-            weatherService.saveWeathersAsync(location.getId(), weatherList);
+        List<Weather> weatherList = createWeatherIfRequired(location, member);
+        if (weatherList != null) {
             return WeatherResponseConverter.toMainPageWeatherData(weatherList, member);
         }
 
-        // 예보를 갱신할 시간이 되었는지 체크
+        updateWeatherIfRequired(location);
+        weatherList = weatherService.getWeathers(location);
+
+        return WeatherResponseConverter.toMainPageWeatherData(weatherList, member);
+    }
+
+    private Location resolveLocation(Member member, Long locationId) {
+        return locationId != null
+                ? locationRepository.safeFindById(locationId)
+                : member.getLocation();
+    }
+
+    private List<Weather> createWeatherIfRequired(Location location, Member member) {
+        if (!weatherQueryService.weatherHasBeenCreated(location)) {
+            List<Weather> weatherList = weatherFeignClientUtils.getVillageShortTermForecast(location);
+            weatherService.bulkSaveWeathersAsync(location.getId(), weatherList);
+            return weatherList;
+        }
+        return null;
+    }
+
+    private void updateWeatherIfRequired(Location location) {
         if (!weatherQueryService.weatherHasBeenUpdated(location)) {
             weatherService.updateWeathersAsync(location.getId());
         }
-
-        List<Weather> weatherList = weatherService.getWeathers(location);
-        return WeatherResponseConverter.toMainPageWeatherData(weatherList, member);
     }
 
     /**

--- a/back/src/main/java/org/pknu/weather/service/WeatherService.java
+++ b/back/src/main/java/org/pknu/weather/service/WeatherService.java
@@ -1,5 +1,14 @@
 package org.pknu.weather.service;
 
+import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeather;
+import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeatherInfo;
+import static org.pknu.weather.dto.converter.LocationConverter.toLocationDTO;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pknu.weather.apiPayload.code.status.ErrorStatus;
@@ -16,24 +25,9 @@ import org.pknu.weather.repository.ExtraWeatherRepository;
 import org.pknu.weather.repository.LocationRepository;
 import org.pknu.weather.repository.MemberRepository;
 import org.pknu.weather.repository.WeatherRepository;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-
-import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeather;
-import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeatherInfo;
-import static org.pknu.weather.dto.converter.LocationConverter.toLocationDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +40,7 @@ public class WeatherService {
     private final MemberRepository memberRepository;
     private final ExtraWeatherApiUtils extraWeatherApiUtils;
     private final LocationRepository locationRepository;
-    private final JdbcTemplate jdbcTemplate;
+
 
     /**
      * TODO: 성능 개선 필요
@@ -104,11 +98,7 @@ public class WeatherService {
     @Transactional
     public void bulkSaveWeathersAsync(Long locationId, List<Weather> newForecast) {
         Location location = locationRepository.safeFindById(locationId);
-        String query =
-                "INSERT INTO weather(basetime, location_id, wind_speed, humidity, rain_prob, rain, rain_type, temperature, sensible_temperature, snow_cover, sky_type, presentation_time) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-
-        batchUpdateWeathers(query, newForecast, location);
+        weatherRepository.batchSave(newForecast, location);
     }
 
     /**
@@ -123,8 +113,8 @@ public class WeatherService {
         Location location = locationRepository.safeFindById(locationId);
         Map<LocalDateTime, Weather> oldWeatherMap = weatherRepository.findAllByLocationAfterNow(location);
         List<Weather> newWeatherList = weatherFeignClientUtils.getVillageShortTermForecast(location);
-        List<Weather> weatherList = updateWeathers(oldWeatherMap, newWeatherList, location);
-        weatherRepository.saveAll(weatherList);
+        List<Weather> weathersList = updateWeathers(oldWeatherMap, newWeatherList, location);
+        weatherRepository.saveAll(weathersList);
     }
 
     @Async("WeatherCUDExecutor")
@@ -134,21 +124,15 @@ public class WeatherService {
         Map<LocalDateTime, Weather> oldWeatherMap = weatherRepository.findAllByLocationAfterNow(location);
         List<Weather> newWeatherList = weatherFeignClientUtils.getVillageShortTermForecast(location);
         List<Weather> weathersList = updateWeathers(oldWeatherMap, newWeatherList, location);
-        String query =
-                "INSERT INTO weather(basetime, location_id, wind_speed, humidity, rain_prob, rain, rain_type, temperature, sensible_temperature, snow_cover, sky_type, presentation_time) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "
-                        + "ON DUPLICATE KEY UPDATE "
-                        + "wind_speed = VALUES(wind_speed), humidity = VALUES(humidity), rain_prob = VALUES(rain_prob), rain = VALUES(rain), rain_type = VALUES(rain_type), sensible_temperature = VALUES(sensible_temperature), snow_cover = VALUES(snow_cover), sky_type = VALUES(sky_type), presentation_time = VALUES(presentation_time)";
-        batchUpdateWeathers(query, weathersList, location);
+        weatherRepository.batchUpdate(weathersList, location);
     }
 
     private List<Weather> updateWeathers(Map<LocalDateTime, Weather> oldWeatherMap, List<Weather> newWeatherList,
                                          Location location) {
+        log.debug("oldWeatherMap size: " + oldWeatherMap.size());
         newWeatherList.forEach(newWeather -> {
             LocalDateTime presentationTime = newWeather.getPresentationTime();
             if (oldWeatherMap.containsKey(presentationTime)) {
-                // 이미 존재하는 데이터 갱신
-//                oldWeatherMap.put(presentationTime, newWeather);
                 Weather oldWeather = oldWeatherMap.get(presentationTime);
                 oldWeather.updateWeather(newWeather);
             } else {
@@ -157,39 +141,10 @@ public class WeatherService {
             }
         });
 
-        return new ArrayList<>(oldWeatherMap.values());
+        log.debug("oldWeatherMap size: " + oldWeatherMap.size());
+        return oldWeatherMap.values().stream().toList();
     }
 
-    private void batchUpdateWeathers(String query, List<Weather> forecast, Location location) {
-        jdbcTemplate.batchUpdate(query,
-                new BatchPreparedStatementSetter() {
-
-                    @Override
-                    public void setValues(PreparedStatement ps, int i) throws SQLException {
-                        Weather w = forecast.get(i);
-                        w.updateSensibleTemperature();
-
-                        ps.setTimestamp(1, Timestamp.valueOf(w.getBasetime()));
-                        ps.setLong(2, location.getId());
-                        ps.setDouble(3, w.getWindSpeed());
-                        ps.setInt(4, w.getHumidity());
-                        ps.setInt(5, w.getRainProb());
-                        ps.setFloat(6, w.getRain());
-                        ps.setInt(7, w.getRainType().ordinal());
-                        ps.setInt(8, w.getTemperature());
-                        ps.setDouble(9, w.getSensibleTemperature());
-                        ps.setFloat(10, w.getSnowCover());
-                        ps.setInt(11, w.getSkyType().ordinal());
-                        ps.setObject(12, w.getPresentationTime());
-                    }
-
-                    @Override
-                    public int getBatchSize() {
-                        log.debug("batch size : {}", forecast.size());
-                        return forecast.size();
-                    }
-                });
-    }
 
     /**
      * 예보 시간이 현재 보다 과거이면 모두 삭제합니다.v

--- a/back/src/main/java/org/pknu/weather/service/WeatherService.java
+++ b/back/src/main/java/org/pknu/weather/service/WeatherService.java
@@ -1,17 +1,5 @@
 package org.pknu.weather.service;
 
-import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeather;
-import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeatherInfo;
-import static org.pknu.weather.dto.converter.LocationConverter.toLocationDTO;
-
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pknu.weather.apiPayload.code.status.ErrorStatus;
@@ -33,6 +21,19 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeather;
+import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeatherInfo;
+import static org.pknu.weather.dto.converter.LocationConverter.toLocationDTO;
 
 @Service
 @RequiredArgsConstructor
@@ -147,6 +148,7 @@ public class WeatherService {
             LocalDateTime presentationTime = newWeather.getPresentationTime();
             if (oldWeatherMap.containsKey(presentationTime)) {
                 // 이미 존재하는 데이터 갱신
+//                oldWeatherMap.put(presentationTime, newWeather);
                 Weather oldWeather = oldWeatherMap.get(presentationTime);
                 oldWeather.updateWeather(newWeather);
             } else {

--- a/back/src/main/java/org/pknu/weather/service/WeatherService.java
+++ b/back/src/main/java/org/pknu/weather/service/WeatherService.java
@@ -109,6 +109,7 @@ public class WeatherService {
      */
     @Async("WeatherCUDExecutor")
     @Transactional
+    @Deprecated
     public void updateWeathersAsync(Long locationId) {
         Location location = locationRepository.safeFindById(locationId);
         Map<LocalDateTime, Weather> oldWeatherMap = weatherRepository.findAllByLocationAfterNow(location);

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -21,7 +21,7 @@ spring:
         default_batch_fetch_size: 500
         format_sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     open-in-view: false   # osiv 설정
   jwt:
     key: ${JWT_KEY}

--- a/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
+++ b/back/src/test/java/org/pknu/weather/domain/WeatherTest.java
@@ -1,6 +1,7 @@
 package org.pknu.weather.domain;
 
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ class WeatherTest {
                 .temperature(14)
                 .humidity(50)
                 .windSpeed(1.5)
+                .presentationTime(LocalDateTime.now())
                 .build();
 
         // when

--- a/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
+++ b/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
@@ -1,6 +1,15 @@
 package org.pknu.weather.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -18,12 +27,6 @@ import org.pknu.weather.repository.WeatherRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-
-import java.time.LocalDateTime;
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
 @Slf4j
@@ -56,14 +59,14 @@ class WeatherServiceTest {
                     .basetime(baseTime)
                     .presentationTime(targetTime.plusHours(i))
                     .location(location)
-                    .rainType(RainType.NONE)
-                    .rain(1.0F)
-                    .rainProb(10)
-                    .temperature(14)
-                    .humidity(50)
-                    .windSpeed(1.5)
-                    .snowCover(1.5f)
-                    .skyType(SkyType.CLEAR)
+                    .rainType(RainType.values()[(int) (Math.random() * RainType.values().length)])
+                    .rain((float) (Math.random() * 10 + i))
+                    .rainProb((int) (Math.random() * 100))
+                    .temperature((int) (Math.random() * 30 + i))
+                    .humidity((int) (Math.random() * 100))
+                    .windSpeed(Math.random() * 10 + i)
+                    .snowCover((float) (Math.random() * 5 + i))
+                    .skyType(SkyType.values()[(int) (Math.random() * SkyType.values().length)])
                     .build();
 
             weatherMap.put(weather.getPresentationTime(), weather);
@@ -83,14 +86,14 @@ class WeatherServiceTest {
                     .basetime(baseTime)
                     .presentationTime(targetTime.plusHours(i))
                     .location(location)
-                    .rainType(RainType.NONE)
-                    .rain(1.0F)
-                    .rainProb(10)
-                    .temperature(14)
-                    .humidity(50)
-                    .windSpeed(1.5)
-                    .snowCover(1.5f)
-                    .skyType(SkyType.CLEAR)
+                    .rainType(RainType.values()[(int) (Math.random() * RainType.values().length)])
+                    .rain((float) (Math.random() * 10 + i))
+                    .rainProb((int) (Math.random() * 100))
+                    .temperature((int) (Math.random() * 30 + i))
+                    .humidity((int) (Math.random() * 100))
+                    .windSpeed(Math.random() * 10 + i)
+                    .snowCover((float) (Math.random() * 5 + i))
+                    .skyType(SkyType.values()[(int) (Math.random() * SkyType.values().length)])
                     .build();
 
             weatherList.add(weather);
@@ -117,7 +120,7 @@ class WeatherServiceTest {
         weatherService.updateWeathersAsync(location.getId());
 
         try {
-            Thread.sleep(1000);
+            Thread.sleep(2000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -142,7 +145,7 @@ class WeatherServiceTest {
         weatherService.saveWeathersAsync(location.getId(), getNewForecast(location, now));
 
         // then
-        Thread.sleep(1000);
+        Thread.sleep(2000);
         List<Weather> weatherList = weatherRepository.findAll();
         Assertions.assertThat(weatherList.size()).isEqualTo(24);
     }
@@ -160,23 +163,14 @@ class WeatherServiceTest {
         weatherService.updateWeathersAsync(location.getId());
 
         // then
-        Thread.sleep(1000);
-        List<Weather> weatherList = weatherRepository.findAll().stream()
-                .sorted(Comparator.comparing(Weather::getPresentationTime))
-                .toList();
-
-        weatherList.forEach(weather -> {
-            log.info("Weather[basetime={}, presentationTime={}, location={}, rainType={}, " +
-                            "rain={}, rainProb={}, temperature={}, humidity={}, windSpeed={}, " +
-                            "snowCover={}, skyType={}]",
-                    weather.getBasetime(), weather.getPresentationTime(),
-                    "location", weather.getRainType(),
-                    weather.getRain(), weather.getRainProb(),
-                    weather.getTemperature(), weather.getHumidity(),
-                    weather.getWindSpeed(), weather.getSnowCover(),
-                    weather.getSkyType());
-        });
-        Assertions.assertThat(weatherList.size()).isEqualTo(24);
+        Thread.sleep(2000);
+        List<Weather> weatherList = weatherRepository.findAll();
+//        weatherList.stream()
+//                .sorted(Comparator.comparing(Weather::getPresentationTime))
+//                .forEach(weather -> {
+//                    log.info("{}", weather.getPresentationTime());
+//                });
+        Assertions.assertThat(weatherList.size()).isEqualTo(27);
     }
 
     @Test
@@ -189,7 +183,7 @@ class WeatherServiceTest {
         weatherService.bulkSaveWeathersAsync(location.getId(), getNewForecast(location, now));
 
         // then
-        Thread.sleep(1000);
+        Thread.sleep(2000);
         List<Weather> weatherList = weatherRepository.findAll();
         Assertions.assertThat(weatherList.size()).isEqualTo(24);
     }
@@ -207,28 +201,19 @@ class WeatherServiceTest {
         weatherService.bulkUpdateWeathersAsync(location.getId());
 
         // then
-        Thread.sleep(1000);
-        List<Weather> weatherList = weatherRepository.findAll().stream()
+        Thread.sleep(2000);
+        List<Weather> weatherList = weatherRepository.findAll();
+        weatherList.stream()
                 .sorted(Comparator.comparing(Weather::getPresentationTime))
-                .toList();
-
-        weatherList.forEach(weather -> {
-            log.info("Weather[basetime={}, presentationTime={}, location={}, rainType={}, " +
-                            "rain={}, rainProb={}, temperature={}, humidity={}, windSpeed={}, " +
-                            "snowCover={}, skyType={}]",
-                    weather.getBasetime(), weather.getPresentationTime(),
-                    "location", weather.getRainType(),
-                    weather.getRain(), weather.getRainProb(),
-                    weather.getTemperature(), weather.getHumidity(),
-                    weather.getWindSpeed(), weather.getSnowCover(),
-                    weather.getSkyType());
-        });
-        Assertions.assertThat(weatherList.size()).isEqualTo(24);
+                .forEach(weather -> {
+                    log.info("{}", weather.getPresentationTime());
+                });
+        Assertions.assertThat(weatherList.size()).isEqualTo(27);
     }
 
     @AfterEach
     void remove() {
-        weatherRepository.deleteAll();
         locationRepository.deleteAll();
+        weatherRepository.deleteAll();
     }
 }

--- a/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
+++ b/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
@@ -1,7 +1,17 @@
 package org.pknu.weather.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,15 +27,6 @@ import org.pknu.weather.repository.WeatherRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
 @Slf4j
@@ -48,11 +49,12 @@ class WeatherServiceTest {
 
     Map<LocalDateTime, Weather> getPastForecast(Location location, LocalDateTime targetTime) {
         // 현재 시각
-        LocalDateTime baseTime = targetTime.minusHours(3);
+        targetTime = targetTime.minusHours(3);
+        LocalDateTime baseTime = targetTime;
         Map<LocalDateTime, Weather> weatherMap = new HashMap<>();
 
         // 3시간 전에 발표한 예보 만들기
-        for(int i = 1; i < 24; i++) {
+        for (int i = 1; i <= 24; i++) {
             Weather weather = Weather.builder()
                     .basetime(baseTime)
                     .presentationTime(targetTime.plusHours(i))
@@ -79,7 +81,7 @@ class WeatherServiceTest {
         List<Weather> weatherList = new ArrayList<>();
 
         // 3시간 전에 발표한 예보 만들기
-        for(int i = 1; i < 24; i++) {
+        for (int i = 1; i <= 24; i++) {
             Weather weather = Weather.builder()
                     .basetime(baseTime)
                     .presentationTime(targetTime.plusHours(i))
@@ -107,8 +109,7 @@ class WeatherServiceTest {
         LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
 
         doReturn(getNewForecast(location, now))
-                .when(weatherFeignClientUtils)
-                .getVillageShortTermForecast(location);
+                .when(weatherFeignClientUtils).getVillageShortTermForecast(location);
 
 //        when(weatherFeignClientUtils.getVillageShortTermForecast(location))
 //                .thenReturn(getNewForecast(location, now));
@@ -119,7 +120,7 @@ class WeatherServiceTest {
         weatherService.updateWeathersAsync(location.getId());
 
         try {
-            Thread.sleep(3000);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
@@ -129,14 +130,94 @@ class WeatherServiceTest {
                 .toList();
 
         updatedWeatherList.stream()
-                        .forEach(weather -> {
-                            assertThat(weather.getBasetime()).isEqualTo(now);
-                        });
+                .forEach(weather -> {
+                    assertThat(weather.getBasetime()).isEqualTo(now);
+                });
+    }
+
+    @Test
+    void 비동기_insert_로직_테스트() throws InterruptedException {
+        // given
+        Location location = locationRepository.saveAndFlush(TestDataCreator.getBusanLocation());
+        LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+
+        // when
+        weatherService.saveWeathersAsync(location.getId(), getNewForecast(location, now));
+
+        // then
+        Thread.sleep(1000);
+        List<Weather> weatherList = weatherRepository.findAll();
+        Assertions.assertThat(weatherList.size()).isEqualTo(24);
+    }
+
+    @Test
+    void 비동기_update_로직_테스트() throws InterruptedException {
+        // given
+        Location location = locationRepository.saveAndFlush(TestDataCreator.getBusanLocation());
+        LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+        weatherRepository.saveAll(getPastForecast(location, now).values());
+        doReturn(getNewForecast(location, now))
+                .when(weatherFeignClientUtils).getVillageShortTermForecast(location);
+
+        // when
+        weatherService.updateWeathersAsync(location.getId());
+
+        // then
+        Thread.sleep(1000);
+        List<Weather> weatherList = weatherRepository.findAll().stream()
+                .sorted(Comparator.comparing(Weather::getPresentationTime))
+                .toList();
+
+        weatherList.forEach(weather -> {
+            log.info("Weather[basetime={}, presentationTime={}, location={}, rainType={}, " +
+                            "rain={}, rainProb={}, temperature={}, humidity={}, windSpeed={}, " +
+                            "snowCover={}, skyType={}]",
+                    weather.getBasetime(), weather.getPresentationTime(),
+                    "location", weather.getRainType(),
+                    weather.getRain(), weather.getRainProb(),
+                    weather.getTemperature(), weather.getHumidity(),
+                    weather.getWindSpeed(), weather.getSnowCover(),
+                    weather.getSkyType());
+        });
+        Assertions.assertThat(weatherList.size()).isEqualTo(24);
+    }
+
+    @Test
+    void 비동기_벌크_insert_로직_테스트() throws InterruptedException {
+        // given
+        Location location = locationRepository.saveAndFlush(TestDataCreator.getBusanLocation());
+        LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+
+        // when
+        weatherService.bulkSaveWeathersAsync(location.getId(), getNewForecast(location, now));
+
+        // then
+        Thread.sleep(1000);
+        List<Weather> weatherList = weatherRepository.findAll();
+        Assertions.assertThat(weatherList.size()).isEqualTo(24);
+    }
+
+    @Test
+    void 비동기_벌크_update_로직_테스트() throws InterruptedException {
+        // given
+        Location location = locationRepository.saveAndFlush(TestDataCreator.getBusanLocation());
+        LocalDateTime now = LocalDateTime.now().withMinute(0).withSecond(0).withNano(0);
+        weatherRepository.saveAll(getPastForecast(location, now).values());
+        doReturn(getNewForecast(location, now))
+                .when(weatherFeignClientUtils).getVillageShortTermForecast(location);
+
+        // when
+        weatherService.bulkUpdateWeathersAsync(location.getId());
+
+        // then
+        Thread.sleep(1000);
+        List<Weather> weatherList = weatherRepository.findAll();
+        Assertions.assertThat(weatherList.size()).isEqualTo(24);
     }
 
     @AfterEach
     void remove() {
-        locationRepository.deleteAll();
         weatherRepository.deleteAll();
+        locationRepository.deleteAll();
     }
 }

--- a/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
+++ b/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
@@ -1,15 +1,6 @@
 package org.pknu.weather.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doReturn;
-
 import jakarta.persistence.EntityManager;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -27,6 +18,12 @@ import org.pknu.weather.repository.WeatherRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
 @Slf4j
@@ -211,7 +208,21 @@ class WeatherServiceTest {
 
         // then
         Thread.sleep(1000);
-        List<Weather> weatherList = weatherRepository.findAll();
+        List<Weather> weatherList = weatherRepository.findAll().stream()
+                .sorted(Comparator.comparing(Weather::getPresentationTime))
+                .toList();
+
+        weatherList.forEach(weather -> {
+            log.info("Weather[basetime={}, presentationTime={}, location={}, rainType={}, " +
+                            "rain={}, rainProb={}, temperature={}, humidity={}, windSpeed={}, " +
+                            "snowCover={}, skyType={}]",
+                    weather.getBasetime(), weather.getPresentationTime(),
+                    "location", weather.getRainType(),
+                    weather.getRain(), weather.getRainProb(),
+                    weather.getTemperature(), weather.getHumidity(),
+                    weather.getWindSpeed(), weather.getSnowCover(),
+                    weather.getSkyType());
+        });
         Assertions.assertThat(weatherList.size()).isEqualTo(24);
     }
 

--- a/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
+++ b/back/src/test/java/org/pknu/weather/service/WeatherServiceTest.java
@@ -1,12 +1,5 @@
 package org.pknu.weather.service;
 
-import static org.mockito.Mockito.doReturn;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
@@ -24,6 +17,14 @@ import org.pknu.weather.repository.WeatherRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.doReturn;
 
 @SpringBootTest
 @Slf4j
@@ -128,7 +129,7 @@ class WeatherServiceTest {
         Assertions.assertThat(weatherList.size()).isEqualTo(24);
     }
 
-    @Test
+//    @Test
     void 비동기_벌크_update_로직_테스트() throws InterruptedException {
         // given
         Location location = locationRepository.saveAndFlush(TestDataCreator.getBusanLocation());

--- a/back/src/test/resources/application.yml
+++ b/back/src/test/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     init:
       mode: never
   datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;TRACE_LEVEL_FILE=4;MODE=MYSQL
     username: sa
     password:
     driver-class-name: org.h2.Driver
@@ -18,7 +18,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
         format_sql: true
-        use_sql_comments: true
+        #        use_sql_comments: true
         default_batch_fetch_size: 500
     hibernate:
       ddl-auto: create

--- a/back/src/test/resources/application.yml
+++ b/back/src/test/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     init:
       mode: never
   datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;TRACE_LEVEL_FILE=4;MODE=MYSQL
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL
     username: sa
     password:
     driver-class-name: org.h2.Driver

--- a/back/src/test/resources/application.yml
+++ b/back/src/test/resources/application.yml
@@ -5,7 +5,7 @@ spring:
     init:
       mode: never
   datasource:
-    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
     username: sa
     password:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
### 이슈 번호(링크)
refactor/417
커밋 수정 예정

### 상황
- `weather` 엔티티의 기본 키 매핑을 `GenerationType.AUTO`로 설정하면서 Table 전략으로 동작, 내부적으로 `weather` 엔티티의 id를 얻기 위해 select, update 쿼리를 날리는 과정에서 커넥션을 하나 더 획득하면서 데드락 발생하였던 것

### 해결
- 모든 엔티티의 기본 키 매핑 전략을 Identity 전략으로 변경
- 이 과정에서 insert/update 쿼리가 하나씩 나가는 현상을 수정하기 위해 Batch insert/update 적용

### 변경해야하는 점
[v] 개발서버 db url에 rewirteBatchedStatements=true 옵션 추가
[v] 운영서버 db url에 rewirteBatchedStatements=true 옵션 추가


