### PR TITLE
Feat#419

### DIFF
--- a/.github/workflows/gradle-dev-ci.yml
+++ b/.github/workflows/gradle-dev-ci.yml
@@ -98,6 +98,10 @@ jobs:
           fcm.project-id: ${{secrets.FCM_ID}}
           fcm.service-account: ${{secrets.FCM_CREDENTIAL}}
           integration-logging: true
+          spring.data.redis.host: ${{secrets.REDIS_HOST}}
+          spring.data.redis.port: ${{secrets.REDIS_PORT}}
+          spring.data.redis.password: ${{secrets.REDIS_PASSWORD}}
+
 
       - name: Build
         working-directory: back

--- a/.github/workflows/gradle-dev-ci.yml
+++ b/.github/workflows/gradle-dev-ci.yml
@@ -98,9 +98,9 @@ jobs:
           fcm.project-id: ${{secrets.FCM_ID}}
           fcm.service-account: ${{secrets.FCM_CREDENTIAL}}
           integration-logging: true
-          spring.data.redis.host: ${{secrets.REDIS_HOST}}
-          spring.data.redis.port: ${{secrets.REDIS_PORT}}
-          spring.data.redis.password: ${{secrets.REDIS_PASSWORD}}
+          spring.data.redis.host: ${{secrets.REDIS_HOST_DEV}}
+          spring.data.redis.port: ${{secrets.REDIS_PORT_DEV}}
+          spring.data.redis.password: ${{secrets.REDIS_PASSWORD_DEV}}
 
 
       - name: Build

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -90,6 +90,11 @@ dependencies {
 
     //FCM
     implementation 'com.google.firebase:firebase-admin:9.4.3'
+
+    // Spring Data Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
 }
 tasks.named('test') {
     useJUnitPlatform()

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -94,7 +94,11 @@ dependencies {
     // Spring Data Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // Embeded Redis
     testImplementation 'com.github.codemonstur:embedded-redis:1.4.3'
+
+    // 비동기 코드 테스트를 위한 Awaitility
+    testImplementation group: 'org.awaitility', name: 'awaitility', version: '4.3.0'
 }
 tasks.named('test') {
     useJUnitPlatform()

--- a/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
+++ b/back/src/main/java/org/pknu/weather/config/AsyncConfig.java
@@ -31,4 +31,15 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "AlarmExecutor")
+    public Executor getAlarmAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(200);
+        executor.setThreadNamePrefix("Alarm Executor-");
+        executor.initialize();
+        return executor;
+    }
 }

--- a/back/src/main/java/org/pknu/weather/controller/AlarmControllerV2.java
+++ b/back/src/main/java/org/pknu/weather/controller/AlarmControllerV2.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.pknu.weather.apiPayload.ApiResponse;
 import org.pknu.weather.common.converter.TokenConverter;
+import org.pknu.weather.domain.common.AlarmType;
 import org.pknu.weather.dto.AlarmRequestDTO;
 import org.pknu.weather.dto.AlarmResponseDTO;
 import org.pknu.weather.service.AlarmService;
@@ -53,7 +54,9 @@ public class AlarmControllerV2 {
                                          @RequestBody Map<String, String> payload) {
 
         String email = TokenConverter.getEmailByToken(authorization);
-        alarmService.testAlarm(email, payload.get("fcmToken"));
+        Map<String, String> testArgs = Map.of("email", email, "fcmToken", payload.get("fcmToken"));
+
+        alarmService.trigger(AlarmType.TEST_WEATHER_SUMMARY, testArgs);
         return ApiResponse.onSuccess();
     }
 }

--- a/back/src/main/java/org/pknu/weather/controller/PostControllerV1.java
+++ b/back/src/main/java/org/pknu/weather/controller/PostControllerV1.java
@@ -1,7 +1,9 @@
 package org.pknu.weather.controller;
 
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.pknu.weather.aop.util.ExecutionTimerUtils;
 import org.pknu.weather.apiPayload.ApiResponse;
 import org.pknu.weather.common.converter.TokenConverter;
 import org.pknu.weather.dto.PostRequest;
@@ -27,9 +29,12 @@ public class PostControllerV1 {
     @PostMapping("/post")
     public ApiResponse<Object> createWeatherPost(@RequestHeader("Authorization") String authorization,
                                                  @Valid @RequestBody PostRequest.Params params) {
+        long start = ExecutionTimerUtils.start();
         PostRequest.CreatePost createPost = PostRequestConverter.toCreatePost(params);
         String email = TokenConverter.getEmailByToken(authorization);
         boolean isSuccess = postService.createWeatherPost(email, createPost);
+        long end = ExecutionTimerUtils.end(start);
+        System.out.println("비동기 테스트: " + end + "ms");
         return ApiResponse.of(isSuccess);
     }
 

--- a/back/src/main/java/org/pknu/weather/controller/PostControllerV1.java
+++ b/back/src/main/java/org/pknu/weather/controller/PostControllerV1.java
@@ -29,12 +29,9 @@ public class PostControllerV1 {
     @PostMapping("/post")
     public ApiResponse<Object> createWeatherPost(@RequestHeader("Authorization") String authorization,
                                                  @Valid @RequestBody PostRequest.Params params) {
-        long start = ExecutionTimerUtils.start();
         PostRequest.CreatePost createPost = PostRequestConverter.toCreatePost(params);
         String email = TokenConverter.getEmailByToken(authorization);
         boolean isSuccess = postService.createWeatherPost(email, createPost);
-        long end = ExecutionTimerUtils.end(start);
-        System.out.println("비동기 테스트: " + end + "ms");
         return ApiResponse.of(isSuccess);
     }
 

--- a/back/src/main/java/org/pknu/weather/domain/common/AlarmType.java
+++ b/back/src/main/java/org/pknu/weather/domain/common/AlarmType.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
+import org.pknu.weather.event.alarm.LiveRainAlarmCreatedEvent;
 
 @RequiredArgsConstructor
 @Getter
@@ -11,7 +12,7 @@ import lombok.ToString;
 public enum AlarmType {
 
     WEATHER_SUMMARY("날씨 요약 알림", Void.class),
-    RAIN_ALERT("실시간 비 알림", Void.class),
+    RAIN_ALERT("실시간 비 알림", LiveRainAlarmCreatedEvent.class),
     WEATHER_UPDATE("날씨 데이터 업데이트", Void.class),
     TEST_WEATHER_SUMMARY("날씨 요약 알림 테스트", Map.class);
 

--- a/back/src/main/java/org/pknu/weather/event/alarm/AlarmEventListener.java
+++ b/back/src/main/java/org/pknu/weather/event/alarm/AlarmEventListener.java
@@ -3,6 +3,7 @@ package org.pknu.weather.event.alarm;
 import lombok.RequiredArgsConstructor;
 import org.pknu.weather.domain.common.AlarmType;
 import org.pknu.weather.service.AlarmService;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class AlarmEventListener {
 
     private final AlarmService alarmService;
 
+    @Async("AlarmExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(LiveRainAlarmCreatedEvent event) {
         alarmService.trigger(AlarmType.RAIN_ALERT, event);

--- a/back/src/main/java/org/pknu/weather/event/alarm/AlarmEventListener.java
+++ b/back/src/main/java/org/pknu/weather/event/alarm/AlarmEventListener.java
@@ -1,0 +1,21 @@
+package org.pknu.weather.event.alarm;
+
+import lombok.RequiredArgsConstructor;
+import org.pknu.weather.domain.common.AlarmType;
+import org.pknu.weather.service.AlarmService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class AlarmEventListener {
+
+    private final AlarmService alarmService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(LiveRainAlarmCreatedEvent event) {
+        alarmService.trigger(AlarmType.RAIN_ALERT, event);
+    }
+
+}

--- a/back/src/main/java/org/pknu/weather/event/alarm/AlarmTriggerEvent.java
+++ b/back/src/main/java/org/pknu/weather/event/alarm/AlarmTriggerEvent.java
@@ -1,0 +1,8 @@
+package org.pknu.weather.event.alarm;
+
+import java.time.LocalDateTime;
+
+
+public interface AlarmTriggerEvent {
+    LocalDateTime getOccurredAt();
+}

--- a/back/src/main/java/org/pknu/weather/event/alarm/LiveRainAlarmCreatedEvent.java
+++ b/back/src/main/java/org/pknu/weather/event/alarm/LiveRainAlarmCreatedEvent.java
@@ -1,0 +1,17 @@
+package org.pknu.weather.event.alarm;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LiveRainAlarmCreatedEvent implements AlarmTriggerEvent{
+    private final long postId;
+    private final LocalDateTime occurredTime = LocalDateTime.now();
+
+    @Override
+    public LocalDateTime getOccurredAt() {
+        return this.occurredTime;
+    }
+}

--- a/back/src/main/java/org/pknu/weather/repository/AlarmRepository.java
+++ b/back/src/main/java/org/pknu/weather/repository/AlarmRepository.java
@@ -1,9 +1,11 @@
 package org.pknu.weather.repository;
 
 
+import java.util.List;
 import java.util.Optional;
 import org.pknu.weather.domain.Alarm;
 import org.pknu.weather.domain.Member;
+import org.pknu.weather.service.dto.LiveRainAlarmInfo;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,5 +17,11 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     @EntityGraph(attributePaths = {"summaryAlarmTimes"})
     @Query("SELECT a FROM Alarm a WHERE a.member = :member")
     Optional<Alarm> findByMemberWithSummaryAlarmTimes(@Param("member") Member member);
+
+
+    @Query("SELECT a.fcmToken " +
+            "FROM Alarm a JOIN a.member m JOIN m.location l " +
+            "WHERE l.id = :locationId AND a.agreeLiveRainAlarm = true")
+    List<String> findLiveRainAlarmInfo(@Param("locationId") Long locationId);
 
 }

--- a/back/src/main/java/org/pknu/weather/service/AlarmCooldownService.java
+++ b/back/src/main/java/org/pknu/weather/service/AlarmCooldownService.java
@@ -1,0 +1,34 @@
+package org.pknu.weather.service;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.pknu.weather.domain.common.AlarmType;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmCooldownService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String COOLDOWN_KEY_PREFIX = "alarm:cooldown:";
+    private static final Duration DEFAULT_COOLDOWN_DURATION = Duration.ofHours(4);
+
+    public boolean isInCooldown(AlarmType type, String identifier) {
+        String key = generateKey(type, identifier);
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void setCooldown(AlarmType type, String identifier) {
+        String key = generateKey(type, identifier);
+        redisTemplate.opsForValue().set(key, "1", DEFAULT_COOLDOWN_DURATION);
+    }
+
+    public void setCooldown(AlarmType type, String identifier, int hour) {
+        String key = generateKey(type, identifier);
+        redisTemplate.opsForValue().set(key, "1", Duration.ofHours(hour));
+    }
+
+    private String generateKey(AlarmType type,String identifier) {
+        return COOLDOWN_KEY_PREFIX + type.name().toLowerCase() + ":" + identifier;
+    }
+}

--- a/back/src/main/java/org/pknu/weather/service/AlarmService.java
+++ b/back/src/main/java/org/pknu/weather/service/AlarmService.java
@@ -3,8 +3,6 @@ package org.pknu.weather.service;
 
 import static org.pknu.weather.dto.converter.AlarmConverter.toAlarmResponseDto;
 
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pknu.weather.apiPayload.code.status.ErrorStatus;
@@ -37,6 +35,11 @@ public class AlarmService {
         handler.handleRequest();
     }
 
+    public <T> void trigger(AlarmType alarmType, T args) {
+        ArgsAlarmHandler<T> handler = handlerFactory.getArgsAlarmHandler(alarmType, args);
+        handler.handleRequest(args);
+    }
+
     public void saveAlarm(String email, AlarmRequestDTO alarmRequestDTO) {
         Member member = memberRepository.safeFindByEmail(email);
         Alarm createdAlarm = Alarm.createDefaultAlarm(member, alarmRequestDTO);
@@ -60,9 +63,4 @@ public class AlarmService {
         return toAlarmResponseDto(foundAlarm);
     }
 
-    public void testAlarm(String email, String fcmToken) {
-        Map<String, String> payload = Map.of("email", email, "fcmToken", fcmToken);
-        ArgsAlarmHandler<Map> handler = handlerFactory.getArgsAlarmHandler(AlarmType.TEST_WEATHER_SUMMARY, Map.class);
-        handler.handleRequest(payload);
-    }
 }

--- a/back/src/main/java/org/pknu/weather/service/PostService.java
+++ b/back/src/main/java/org/pknu/weather/service/PostService.java
@@ -9,10 +9,12 @@ import org.pknu.weather.domain.Member;
 import org.pknu.weather.domain.Post;
 import org.pknu.weather.domain.Tag;
 import org.pknu.weather.domain.common.PostType;
+import org.pknu.weather.domain.tag.SkyTag;
 import org.pknu.weather.dto.PostRequest;
 import org.pknu.weather.dto.converter.PostConverter;
 import org.pknu.weather.dto.converter.TagConverter;
 import org.pknu.weather.event.PostCreatedEvent;
+import org.pknu.weather.event.alarm.LiveRainAlarmCreatedEvent;
 import org.pknu.weather.repository.LocationRepository;
 import org.pknu.weather.repository.MemberRepository;
 import org.pknu.weather.repository.PostRepository;
@@ -62,12 +64,14 @@ public class PostService {
         Post post = PostConverter.toPost(member, tag, createPost.getContent());
 
         post.addTag(tag);
-        postRepository.save(post);
+        Post savedPost = postRepository.save(post);
         eventPublisher.publishEvent(new PostCreatedEvent(member.getEmail()));
+
+        if(tag.getSkyTag().equals(SkyTag.RAIN))
+            eventPublisher.publishEvent(new LiveRainAlarmCreatedEvent(savedPost.getId()));
 
         return true;
     }
-
 
     @Transactional
     public boolean createWeatherPostV2(String email, PostRequest.CreatePostAndTagParameters params) {

--- a/back/src/main/java/org/pknu/weather/service/WeatherRefresherService.java
+++ b/back/src/main/java/org/pknu/weather/service/WeatherRefresherService.java
@@ -1,4 +1,4 @@
-package org.pknu.weather.service.supports;
+package org.pknu.weather.service;
 
 import static org.pknu.weather.dto.converter.ExtraWeatherConverter.toExtraWeather;
 import static org.pknu.weather.dto.converter.LocationConverter.toLocationDTO;
@@ -13,8 +13,6 @@ import org.pknu.weather.dto.WeatherResponse.ExtraWeatherInfo;
 import org.pknu.weather.feignClient.utils.ExtraWeatherApiUtils;
 import org.pknu.weather.repository.ExtraWeatherRepository;
 import org.pknu.weather.repository.LocationRepository;
-import org.pknu.weather.service.WeatherQueryService;
-import org.pknu.weather.service.WeatherService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/back/src/main/java/org/pknu/weather/service/dto/LiveRainAlarmInfo.java
+++ b/back/src/main/java/org/pknu/weather/service/dto/LiveRainAlarmInfo.java
@@ -1,0 +1,28 @@
+package org.pknu.weather.service.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.pknu.weather.dto.AlarmMemberDTO;
+import org.pknu.weather.dto.ExtraWeatherSummaryDTO;
+import org.pknu.weather.dto.WeatherSummaryDTO;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LiveRainAlarmInfo implements AlarmInfo{
+    private String fcmToken;
+    private String province;
+    private String city;
+    private String street;
+    private String postContent;
+
+    public String getFullAddress() {
+        return this.province + " " + this.city + " " + this.street;
+    }
+}

--- a/back/src/main/java/org/pknu/weather/service/dto/WeatherSummaryAlarmInfo.java
+++ b/back/src/main/java/org/pknu/weather/service/dto/WeatherSummaryAlarmInfo.java
@@ -10,7 +10,6 @@ import org.pknu.weather.dto.WeatherSummaryDTO;
 
 @Getter
 @Builder
-
 @RequiredArgsConstructor
 public class WeatherSummaryAlarmInfo implements AlarmInfo{
     private final WeatherSummaryDTO weatherSummaryDTO;

--- a/back/src/main/java/org/pknu/weather/service/handler/AlarmHandlerFactory.java
+++ b/back/src/main/java/org/pknu/weather/service/handler/AlarmHandlerFactory.java
@@ -22,15 +22,16 @@ public class AlarmHandlerFactory {
                 .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 알람 타입: " + type));
     }
 
-    public <T> ArgsAlarmHandler<T> getArgsAlarmHandler(AlarmType type, Class<T> expectedArgsType) {
+    public <T> ArgsAlarmHandler<T> getArgsAlarmHandler(AlarmType type, T args) {
 
         ArgsAlarmHandler<?> argsAlarmHandler = argsAlarmHandlers.stream()
                 .filter(handler -> handler.getAlarmType() == type)
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 알람 타입: " + type));
 
-        if (expectedArgsType != type.getArgumentType()) {
-            throw new GeneralException(ErrorStatus._FCMTOKEN_NOT_FOUND);
+        if (!type.getArgumentType().isInstance(args)) {
+            throw new IllegalArgumentException("인자의 타입이 일치하지 않습니다. 기대 타입: "
+                    + type.getArgumentType().getName() + ", 실제 타입: " + args.getClass().getName());
         }
 
         try {

--- a/back/src/main/java/org/pknu/weather/service/handler/LiveRainAlarmHandler.java
+++ b/back/src/main/java/org/pknu/weather/service/handler/LiveRainAlarmHandler.java
@@ -1,0 +1,73 @@
+package org.pknu.weather.service.handler;
+
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pknu.weather.domain.Location;
+import org.pknu.weather.domain.Post;
+import org.pknu.weather.domain.common.AlarmType;
+import org.pknu.weather.event.alarm.LiveRainAlarmCreatedEvent;
+import org.pknu.weather.repository.AlarmRepository;
+import org.pknu.weather.repository.PostRepository;
+import org.pknu.weather.service.AlarmCooldownService;
+import org.pknu.weather.service.dto.LiveRainAlarmInfo;
+import org.pknu.weather.service.message.AlarmMessageMaker;
+import org.pknu.weather.service.sender.NotificationMessage;
+import org.pknu.weather.service.sender.NotificationSender;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class LiveRainAlarmHandler implements ArgsAlarmHandler<LiveRainAlarmCreatedEvent>{
+
+    private final AlarmRepository alarmRepository;
+    private final AlarmMessageMaker liveRainAlarmMessageMaker;
+    private final NotificationSender sender;
+    private final AlarmCooldownService alarmCooldownService;
+    private final PostRepository postRepository;
+
+    @Override
+    public AlarmType getAlarmType() {
+        return AlarmType.RAIN_ALERT;
+    }
+
+    @Override
+    public void handleRequest(LiveRainAlarmCreatedEvent event) {
+        long postId = event.getPostId();
+        Post post = postRepository.safeFindById(postId);
+        Location location = post.getLocation();
+
+        List<String> fcmTokens = alarmRepository.findLiveRainAlarmInfo(location.getId());
+
+        fcmTokens.stream()
+                .filter(fcmToken -> !alarmCooldownService.isInCooldown(getAlarmType(), fcmToken))
+                .map(fcmToken -> getLiveRainAlarmInfo(post, location, fcmToken))
+                .forEach(this::sendLiveRainAlarm);
+    }
+
+    private void sendLiveRainAlarm(LiveRainAlarmInfo info) {
+        try {
+            NotificationMessage message = liveRainAlarmMessageMaker.createAlarmMessage(info);
+            sender.send(message);
+
+            alarmCooldownService.setCooldown(getAlarmType(), info.getFcmToken());
+        } catch (RuntimeException e) {
+            log.warn("[실시간 비 알림 실패] fcmToken={}, reason={}", info.getFcmToken(), e.getMessage(), e);
+        }
+    }
+
+    private static LiveRainAlarmInfo getLiveRainAlarmInfo(Post post, Location location, String fcmToken) {
+        return LiveRainAlarmInfo.builder()
+                .postContent(post.getContent())
+                .fcmToken(fcmToken)
+                .province(location.getProvince())
+                .city(location.getCity())
+                .street(location.getStreet())
+                .build();
+    }
+}
+

--- a/back/src/main/java/org/pknu/weather/service/handler/TestWeatherSummaryAlarmHandler.java
+++ b/back/src/main/java/org/pknu/weather/service/handler/TestWeatherSummaryAlarmHandler.java
@@ -24,7 +24,7 @@ import org.pknu.weather.service.dto.WeatherSummaryAlarmInfo;
 import org.pknu.weather.service.message.AlarmMessageMaker;
 import org.pknu.weather.service.sender.NotificationMessage;
 import org.pknu.weather.service.sender.NotificationSender;
-import org.pknu.weather.service.supports.WeatherRefresherService;
+import org.pknu.weather.service.WeatherRefresherService;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/back/src/main/java/org/pknu/weather/service/handler/WeatherSummaryAlarmHandler.java
+++ b/back/src/main/java/org/pknu/weather/service/handler/WeatherSummaryAlarmHandler.java
@@ -23,7 +23,7 @@ import org.pknu.weather.service.dto.WeatherSummaryAlarmInfo;
 import org.pknu.weather.dto.WeatherSummaryDTO;
 import org.pknu.weather.service.supports.AlarmTimeUtil;
 import org.pknu.weather.domain.common.AlarmType;
-import org.pknu.weather.service.supports.WeatherRefresherService;
+import org.pknu.weather.service.WeatherRefresherService;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/back/src/main/java/org/pknu/weather/service/handler/WeatherUpdateHandler.java
+++ b/back/src/main/java/org/pknu/weather/service/handler/WeatherUpdateHandler.java
@@ -10,7 +10,7 @@ import org.pknu.weather.repository.MemberRepository;
 import org.pknu.weather.dto.AlarmMemberDTO;
 import org.pknu.weather.service.supports.AlarmTimeUtil;
 import org.pknu.weather.domain.common.AlarmType;
-import org.pknu.weather.service.supports.WeatherRefresherService;
+import org.pknu.weather.service.WeatherRefresherService;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/back/src/main/java/org/pknu/weather/service/message/LiveRainAlarmMessageMaker.java
+++ b/back/src/main/java/org/pknu/weather/service/message/LiveRainAlarmMessageMaker.java
@@ -39,10 +39,10 @@ public class LiveRainAlarmMessageMaker implements AlarmMessageMaker {
     @Override
     public void validate(AlarmInfo alarmInfo) {
         if (!(alarmInfo instanceof LiveRainAlarmInfo liveRainAlarmInfo)) {
-            log.warn("유효성 검사 실패: LivaRainAlarmMessageMaker는 {} 타입만 처리 가능. 입력 타입: {}",
+            log.warn("유효성 검사 실패: LiveRainAlarmMessageMaker는 {} 타입만 처리 가능. 입력 타입: {}",
                     LiveRainAlarmMessageMaker.class.getSimpleName(),
                     alarmInfo != null ? alarmInfo.getClass().getName() : "null");
-            throw new IllegalArgumentException("LivaRainAlarmMessageMaker는 LivaRainAlarmInfo만 처리할 수 있습니다.");
+            throw new IllegalArgumentException("LiveRainAlarmMessageMaker는 LiveRainAlarmInfo만 처리할 수 있습니다.");
         }
 
         validateAlarmAgreement(liveRainAlarmInfo);

--- a/back/src/main/java/org/pknu/weather/service/message/LiveRainAlarmMessageMaker.java
+++ b/back/src/main/java/org/pknu/weather/service/message/LiveRainAlarmMessageMaker.java
@@ -1,0 +1,78 @@
+package org.pknu.weather.service.message;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pknu.weather.domain.common.AlarmType;
+import org.pknu.weather.service.dto.AlarmInfo;
+import org.pknu.weather.service.dto.LiveRainAlarmInfo;
+import org.pknu.weather.service.sender.FcmMessage;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LiveRainAlarmMessageMaker implements AlarmMessageMaker {
+
+    @Override
+    public FcmMessage createAlarmMessage(AlarmInfo alarmInfo) {
+
+        validate(alarmInfo);
+
+        return createLiveRainAlarm((LiveRainAlarmInfo) alarmInfo);
+    }
+
+    private FcmMessage createLiveRainAlarm(LiveRainAlarmInfo liveRainAlarmInfo) {
+
+        String messageBody = getMessageBody(liveRainAlarmInfo);
+
+        return new FcmMessage(liveRainAlarmInfo.getFcmToken(), AlarmType.RAIN_ALERT.getDescription(), messageBody);
+    }
+
+    private static String getMessageBody(LiveRainAlarmInfo liveRainAlarmInfo) {
+        if(liveRainAlarmInfo.getPostContent() == null || liveRainAlarmInfo.getPostContent().isBlank())
+            return "☔️ " + liveRainAlarmInfo.getFullAddress() + "에서 비가 온다는 소식이 공유되었습니다!";
+
+        return "☔️ " + liveRainAlarmInfo.getFullAddress() + "에서 비가 온다는 글이 올라왔습니다!\n"
+                + liveRainAlarmInfo.getPostContent();
+    }
+
+    @Override
+    public void validate(AlarmInfo alarmInfo) {
+        if (!(alarmInfo instanceof LiveRainAlarmInfo liveRainAlarmInfo)) {
+            log.warn("유효성 검사 실패: LivaRainAlarmMessageMaker는 {} 타입만 처리 가능. 입력 타입: {}",
+                    LiveRainAlarmMessageMaker.class.getSimpleName(),
+                    alarmInfo != null ? alarmInfo.getClass().getName() : "null");
+            throw new IllegalArgumentException("LivaRainAlarmMessageMaker는 LivaRainAlarmInfo만 처리할 수 있습니다.");
+        }
+
+        validateAlarmAgreement(liveRainAlarmInfo);
+    }
+
+
+    private void validateAlarmAgreement(LiveRainAlarmInfo info) {
+        String fcmToken =  info.getFcmToken();
+        String province =  info.getProvince();
+        String city =  info.getCity();
+        String street =  info.getStreet();
+
+        if (fcmToken == null || fcmToken.isBlank()) {
+            log.error("유효성 검사 실패: fcmToken이 비어있습니다.");
+            throw new IllegalStateException("fcmToken이 비어있습니다.");
+        }
+
+        if (province == null || province.isBlank()) {
+            log.error("유효성 검사 실패: 지역의 도/시(province)가 비어있습니다.");
+            throw new IllegalStateException("지역의 도/시(province)가 비어있습니다.");
+        }
+        if (city == null || city.isBlank()) {
+            log.error("유효성 검사 실패: 지역의 시/군/구(city)가 비어있습니다.");
+            throw new IllegalStateException("지역의 시/군/구(city)가 비어있습니다.");
+        }
+
+        if (street == null || street.isBlank()) {
+            log.error("유효성 검사 실패: 지역의 읍/면/동(street)가 비어있습니다.");
+            throw new IllegalStateException("지역의 읍/면/동(street)가 비어있습니다.");
+        }
+
+    }
+}

--- a/back/src/main/resources/application.yml
+++ b/back/src/main/resources/application.yml
@@ -40,6 +40,13 @@ spring:
       location: /uploadImg
       max-request-size: 30MB
       max-file-size: 10MB
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
+      ssl:
+        enabled: true
 
   cache:
     type: caffeine

--- a/back/src/test/java/org/pknu/weather/config/EmbeddedRedisConfig.java
+++ b/back/src/test/java/org/pknu/weather/config/EmbeddedRedisConfig.java
@@ -1,0 +1,27 @@
+package org.pknu.weather.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import org.springframework.boot.test.context.TestConfiguration;
+import redis.embedded.RedisServer;
+
+@TestConfiguration
+public class EmbeddedRedisConfig {
+
+    private final RedisServer redisServer;
+
+    public EmbeddedRedisConfig() throws IOException {
+        this.redisServer = new RedisServer(63790);
+    }
+
+    @PostConstruct
+    public void start() throws IOException {
+        this.redisServer.start();
+    }
+
+    @PreDestroy
+    public void stop() throws IOException {
+        this.redisServer.stop();
+    }
+}

--- a/back/src/test/java/org/pknu/weather/controller/CommunityControllerV1Test.java
+++ b/back/src/test/java/org/pknu/weather/controller/CommunityControllerV1Test.java
@@ -18,6 +18,9 @@ import org.pknu.weather.service.PostService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +45,7 @@ class CommunityControllerV1Test {
 
     @Test
     @Transactional
+    @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
     void 게시글조회성공_작성자정보와레벨함꼐반환() throws Exception {
         // given
         Member member = memberRepository.save(TestDataCreator.getBusanMember("test1"));

--- a/back/src/test/java/org/pknu/weather/integration/AlarmSendTest.java
+++ b/back/src/test/java/org/pknu/weather/integration/AlarmSendTest.java
@@ -48,12 +48,12 @@ import org.pknu.weather.security.util.JWTUtil;
 import org.pknu.weather.service.AlarmService;
 import org.pknu.weather.service.dto.AlarmInfo;
 import org.pknu.weather.service.dto.WeatherSummaryAlarmInfo;
-import org.pknu.weather.service.message.AlarmMessageMaker;
+import org.pknu.weather.service.message.WeatherSummaryMessageMaker;
 import org.pknu.weather.service.sender.FcmMessage;
 import org.pknu.weather.service.sender.NotificationMessage;
 import org.pknu.weather.service.sender.NotificationSender;
 import org.pknu.weather.domain.common.AlarmType;
-import org.pknu.weather.service.supports.WeatherRefresherService;
+import org.pknu.weather.service.WeatherRefresherService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -61,7 +61,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.annotation.DirtiesContext.MethodMode;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,7 +98,7 @@ class AlarmSendTest {
     private ExtraWeatherRepository extraWeatherRepository;
 
     @SpyBean
-    private AlarmMessageMaker weatherSummaryMessageMaker;
+    private WeatherSummaryMessageMaker weatherSummaryMessageMaker;
 
     @SpyBean
     private NotificationSender sender;
@@ -239,13 +238,13 @@ class AlarmSendTest {
         alarmService.trigger(AlarmType.WEATHER_SUMMARY);
 
         // Then
-        verify(weatherSummaryMessageMaker,times(DUMMY_DATA_SIZE)).createAlarmMessage(alarmInfoArgumentCaptor.capture());
+        verify(weatherSummaryMessageMaker, times(DUMMY_DATA_SIZE)).createAlarmMessage(alarmInfoArgumentCaptor.capture());
         for (AlarmInfo alarmInfo:alarmInfoArgumentCaptor.getAllValues()) {
             checkAlarmInfo(alarmInfo, memberIds, locationIds);
         }
 
         // 멤버들의 수(DUMMY_DATA_SIZE) 만큼 메시지 전송 시도
-        verify(sender,times(DUMMY_DATA_SIZE)).send(notificationMessageArgumentCaptor.capture());
+        verify(sender, times(DUMMY_DATA_SIZE)).send(notificationMessageArgumentCaptor.capture());
         for (NotificationMessage notificationMessage:notificationMessageArgumentCaptor.getAllValues()) {
             checkFcmMessage(notificationMessage, fcmTokens);
         }

--- a/back/src/test/java/org/pknu/weather/integration/LiveRainAlarmSendTest.java
+++ b/back/src/test/java/org/pknu/weather/integration/LiveRainAlarmSendTest.java
@@ -1,0 +1,168 @@
+package org.pknu.weather.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import jakarta.persistence.EntityManager;
+import java.util.Objects;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.pknu.weather.config.EmbeddedRedisConfig;
+import org.pknu.weather.domain.Alarm;
+import org.pknu.weather.domain.Location;
+import org.pknu.weather.domain.Member;
+import org.pknu.weather.domain.common.AlarmType;
+import org.pknu.weather.domain.tag.DustTag;
+import org.pknu.weather.domain.tag.HumidityTag;
+import org.pknu.weather.domain.tag.SkyTag;
+import org.pknu.weather.domain.tag.TemperatureTag;
+import org.pknu.weather.domain.tag.WindTag;
+import org.pknu.weather.dto.PostRequest.CreatePost;
+import org.pknu.weather.repository.AlarmRepository;
+import org.pknu.weather.repository.LocationRepository;
+import org.pknu.weather.repository.MemberRepository;
+import org.pknu.weather.service.AlarmCooldownService;
+import org.pknu.weather.service.PostService;
+import org.pknu.weather.service.sender.FcmMessage;
+import org.pknu.weather.service.sender.NotificationSender;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@Import(EmbeddedRedisConfig.class)
+public class LiveRainAlarmSendTest {
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+    @Autowired
+    private PostService postService;
+    @SpyBean
+    private AlarmCooldownService alarmCooldownService;
+    @SpyBean
+    private NotificationSender sender;
+
+    @Autowired
+    private LocationRepository locationRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private AlarmRepository alarmRepository;
+    @Autowired
+    private EntityManager entityManager;
+
+    private Member postMember;
+    private Alarm savedAlarm;
+
+    @BeforeEach
+    void setUp() {
+        Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().serverCommands().flushAll();
+
+        Location location = Location.builder()
+                .province("testProvince")
+                .city("testCity")
+                .street("testStreet")
+                .build();
+
+        locationRepository.save(location);
+        Member member1 = Member.builder()
+                .email( UUID.randomUUID() + "testEmail1")
+                .location(location)
+                .build();
+        postMember = memberRepository.save(member1);
+        Member member2 = Member.builder()
+                .email( UUID.randomUUID() + "testEmail2")
+                .location(location)
+                .build();
+        Member savedMember = memberRepository.save(member2);
+
+        Alarm alarm = Alarm.builder()
+                .member(savedMember)
+                .fcmToken("testFcmToken")
+                .agreeUvAlarm(true)
+                .agreePrecipAlarm(true)
+                .agreeTempAlarm(true)
+                .agreeDustAlarm(true)
+                .agreeLiveRainAlarm(true)
+                .build();
+
+        savedAlarm = alarmRepository.save(alarm);
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+
+    @Test
+    void 비가_온다는_태그_저장시_같은_지역의_사용자에게_알림이_전송된다() {
+        String email = postMember.getEmail();
+        CreatePost createPost = CreatePost.builder()
+                .content("testContent")
+                .dustTag(DustTag.NORMAL)
+                .humidityTag(HumidityTag.PLEASANT)
+                .windTag(WindTag.NONE)
+                .temperatureTag(TemperatureTag.COMMON)
+                .skyTag(SkyTag.RAIN)
+                .build();
+
+        postService.createWeatherPost(email, createPost);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        verify(alarmCooldownService, times(1)).setCooldown(AlarmType.RAIN_ALERT, savedAlarm.getFcmToken());
+        verify(sender, times(1)).send(any(FcmMessage.class));
+
+    }
+
+    @Test
+    void 비가_온다는_태그가_아닌_다른_태그_저장시_같은_지역의_사용자에게_알림이_전송되지_않는다() {
+        String email = postMember.getEmail();
+        CreatePost createPost = CreatePost.builder()
+                .content("testContent")
+                .dustTag(DustTag.NORMAL)
+                .humidityTag(HumidityTag.PLEASANT)
+                .windTag(WindTag.NONE)
+                .temperatureTag(TemperatureTag.COMMON)
+                .skyTag(SkyTag.CLOUDY)
+                .build();
+
+        postService.createWeatherPost(email, createPost);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        verify(alarmCooldownService, times(0)).setCooldown(AlarmType.RAIN_ALERT, savedAlarm.getFcmToken());
+        verify(sender, times(0)).send(any(FcmMessage.class));
+
+    }
+
+    @Test
+    void 쿨다운_상태인_사용자에게는_알림이_전송되지_않는다() {
+        alarmCooldownService.setCooldown(AlarmType.RAIN_ALERT, savedAlarm.getFcmToken());
+        String email = postMember.getEmail();
+        CreatePost createPost = CreatePost.builder()
+                .content("testContent")
+                .dustTag(DustTag.NORMAL)
+                .humidityTag(HumidityTag.PLEASANT)
+                .windTag(WindTag.NONE)
+                .temperatureTag(TemperatureTag.COMMON)
+                .skyTag(SkyTag.RAIN)
+                .build();
+
+        postService.createWeatherPost(email, createPost);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // 맨 위에서 미리 저장한 쿨다운 호출 횟수 1번으로 실제 이벤트 과정에서는 호출되지 않습니다.
+        verify(alarmCooldownService, times(1)).setCooldown(AlarmType.RAIN_ALERT, savedAlarm.getFcmToken());
+        verify(sender, times(0)).send(any(FcmMessage.class));
+
+    }
+}

--- a/back/src/test/java/org/pknu/weather/repository/LocationRepositoryTest.java
+++ b/back/src/test/java/org/pknu/weather/repository/LocationRepositoryTest.java
@@ -57,7 +57,7 @@ class LocationRepositoryTest {
                     .presentationTime(
                             DateTimeFormatter.formattedDateTime2LocalDateTime(
                                     DateTimeFormatter.getFormattedLocalDate(
-                                            LocalDate.of(now.getYear(), now.getMonth(), now.getDayOfMonth() - 1)),
+                                            LocalDate.now().minusDays(1)),
                                     DateTimeFormatter.getFormattedTimeByOneHour(LocalTime.of(i, 0))))
                     .temperature(14)
                     .humidity(50)

--- a/back/src/test/java/org/pknu/weather/service/PostServiceTest.java
+++ b/back/src/test/java/org/pknu/weather/service/PostServiceTest.java
@@ -31,10 +31,13 @@ import org.pknu.weather.repository.RecommendationRepository;
 import org.pknu.weather.repository.WeatherRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
 @Slf4j
+@SpringBootTest
+@DirtiesContext(classMode = ClassMode.BEFORE_CLASS)
 class PostServiceTest {
 
     @Autowired

--- a/back/src/test/java/org/pknu/weather/service/handler/LiveRainAlarmHandlerTest.java
+++ b/back/src/test/java/org/pknu/weather/service/handler/LiveRainAlarmHandlerTest.java
@@ -1,0 +1,178 @@
+package org.pknu.weather.service.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.pknu.weather.domain.Location;
+import org.pknu.weather.domain.Post;
+import org.pknu.weather.domain.common.AlarmType;
+import org.pknu.weather.event.alarm.LiveRainAlarmCreatedEvent;
+import org.pknu.weather.repository.AlarmRepository;
+import org.pknu.weather.repository.PostRepository;
+import org.pknu.weather.service.AlarmCooldownService;
+import org.pknu.weather.service.dto.LiveRainAlarmInfo;
+import org.pknu.weather.service.message.AlarmMessageMaker;
+import org.pknu.weather.service.sender.FcmMessage;
+import org.pknu.weather.service.sender.NotificationMessage;
+import org.pknu.weather.service.sender.NotificationSender;
+
+@ExtendWith(MockitoExtension.class)
+class LiveRainAlarmHandlerTest {
+
+    @Mock
+    private AlarmRepository alarmRepository;
+    @Mock
+    private AlarmMessageMaker liveRainAlarmMessageMaker;
+    @Mock
+    private NotificationSender sender;
+    @Mock
+    private AlarmCooldownService alarmCooldownService;
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private LiveRainAlarmHandler liveRainAlarmHandler;
+
+    private Location testLocation;
+    private Post testPost;
+    private LiveRainAlarmCreatedEvent testEvent;
+
+    @BeforeEach
+    void setUp() {
+        testLocation = Location.builder()
+                .id(100L)
+                .province("서울특별시")
+                .city("마포구")
+                .street("상수동")
+                .build();
+
+        testPost = Post.builder()
+                .id(1L)
+                .content("지금 비가 내리기 시작했습니다!")
+                .location(testLocation)
+                .build();
+
+        testEvent = new LiveRainAlarmCreatedEvent(testPost.getId());
+
+        when(postRepository.safeFindById(testEvent.getPostId())).thenReturn(testPost);
+
+    }
+
+    @Test
+    @DisplayName("쿨다운 중이 아닌 사용자에게 알림이 전송되고 쿨다운이 설정되어야 한다")
+    void handleRequest_SendsAlarmAndSetsCooldownToNonCooldownUsers() {
+
+        // Given
+        String fcmToken1 = "fcm_token_1";
+        String fcmToken2 = "fcm_token_2";
+        List<String> fcmTokens = Arrays.asList(fcmToken1, fcmToken2);
+        NotificationMessage expectedMessage1 = new FcmMessage(fcmToken1, "실시간 비 알림", "☔️ 서울특별시 마포구 상수동에서 비가 온다는 소식이 공유되었습니다!");
+        NotificationMessage expectedMessage2 = new FcmMessage(fcmToken2, "실시간 비 알림", "☔️ 서울특별시 마포구 상수동에서 비가 온다는 소식이 공유되었습니다!");
+
+        when(alarmRepository.findLiveRainAlarmInfo(testLocation.getId())).thenReturn(fcmTokens);
+        when(alarmCooldownService.isInCooldown(eq(AlarmType.RAIN_ALERT), any(String.class))).thenReturn(false);
+
+        when(liveRainAlarmMessageMaker.createAlarmMessage(any(LiveRainAlarmInfo.class)))
+                .thenAnswer(invocation -> {
+                    LiveRainAlarmInfo info = invocation.getArgument(0);
+                    if (info.getFcmToken().equals(fcmToken1)) return expectedMessage1;
+                    if (info.getFcmToken().equals(fcmToken2)) return expectedMessage2;
+                    return null;
+                });
+
+        // When
+        liveRainAlarmHandler.handleRequest(testEvent);
+
+        // Then
+        verify(sender, times(1)).send(expectedMessage1);
+        verify(sender, times(1)).send(expectedMessage2);
+
+        verify(alarmCooldownService, times(1)).setCooldown(AlarmType.RAIN_ALERT, fcmToken1);
+        verify(alarmCooldownService, times(1)).setCooldown(AlarmType.RAIN_ALERT, fcmToken2);
+
+        ArgumentCaptor<LiveRainAlarmInfo> infoCaptor = ArgumentCaptor.forClass(LiveRainAlarmInfo.class);
+        verify(liveRainAlarmMessageMaker, times(2)).createAlarmMessage(infoCaptor.capture());
+
+        List<LiveRainAlarmInfo> capturedInfos = infoCaptor.getAllValues();
+        assertThat(capturedInfos).hasSize(2)
+                .extracting(LiveRainAlarmInfo::getFcmToken)
+                .containsExactlyInAnyOrder(fcmToken1, fcmToken2);
+
+        assertThat(capturedInfos).allMatch(info -> info.getProvince().equals("서울특별시") &&
+                info.getCity().equals("마포구") &&
+                info.getStreet().equals("상수동") &&
+                info.getPostContent().equals(testPost.getContent()));
+    }
+
+    @Test
+    @DisplayName("쿨다운 중인 사용자에게는 알림 전송 및 쿨다운 설정이 이루어지지 않아야 한다")
+    void handleRequest_SkipsUsersInCooldown() {
+        // Given
+        String fcmTokenInCooldown = "fcm_token_cooldown";
+        String fcmTokenNotInCooldown = "fcm_token_not_cooldown";
+        List<String> fcmTokens = Arrays.asList(fcmTokenInCooldown, fcmTokenNotInCooldown);
+
+        NotificationMessage expectedMessageForNotInCooldown = new FcmMessage(fcmTokenNotInCooldown, "실시간 비 알림", "☔️ 서울특별시 마포구 상수동에서 비가 온다는 소식이 공유되었습니다!");
+
+        when(alarmRepository.findLiveRainAlarmInfo(testLocation.getId())).thenReturn(fcmTokens);
+
+        when(alarmCooldownService.isInCooldown(AlarmType.RAIN_ALERT, fcmTokenInCooldown)).thenReturn(true);
+        when(alarmCooldownService.isInCooldown(AlarmType.RAIN_ALERT, fcmTokenNotInCooldown)).thenReturn(false);
+
+        when(liveRainAlarmMessageMaker.createAlarmMessage(any(LiveRainAlarmInfo.class)))
+                .thenAnswer(invocation -> {
+                    LiveRainAlarmInfo info = invocation.getArgument(0);
+                    if (info.getFcmToken().equals(fcmTokenNotInCooldown)) {
+                        return expectedMessageForNotInCooldown;
+                    }
+                    return null;
+                });
+
+        // When
+        liveRainAlarmHandler.handleRequest(testEvent);
+
+        // Then
+        verify(sender, never()).send(argThat(message -> ((FcmMessage) message).getFcmToken().equals(fcmTokenInCooldown)));
+        verify(alarmCooldownService, never()).setCooldown(AlarmType.RAIN_ALERT, fcmTokenInCooldown);
+
+        verify(sender, times(1)).send(expectedMessageForNotInCooldown);
+        verify(alarmCooldownService, times(1)).setCooldown(AlarmType.RAIN_ALERT, fcmTokenNotInCooldown);
+
+        verify(liveRainAlarmMessageMaker, times(1))
+                .createAlarmMessage(argThat(info -> ((LiveRainAlarmInfo) info).getFcmToken().equals(fcmTokenNotInCooldown)));
+
+        verify(liveRainAlarmMessageMaker, never())
+                .createAlarmMessage(argThat(info -> ((LiveRainAlarmInfo) info).getFcmToken().equals(fcmTokenInCooldown)));
+
+    }
+
+    @Test
+    @DisplayName("FCM 토큰이 없을 경우 아무런 알림도 전송되지 않아야 한다")
+    void handleRequest_NoAlarmsSent_WhenNoFcmTokens() {
+        // Given
+        when(alarmRepository.findLiveRainAlarmInfo(testLocation.getId())).thenReturn(Collections.emptyList());
+
+        // When
+        liveRainAlarmHandler.handleRequest(testEvent);
+
+        // Then
+        verify(sender, never()).send(any());
+    }
+}

--- a/back/src/test/java/org/pknu/weather/service/handler/WeatherSummaryAlarmHandlerTest.java
+++ b/back/src/test/java/org/pknu/weather/service/handler/WeatherSummaryAlarmHandlerTest.java
@@ -47,7 +47,7 @@ import org.pknu.weather.service.message.AlarmMessageMaker;
 import org.pknu.weather.service.sender.NotificationMessage;
 import org.pknu.weather.service.sender.NotificationSender;
 import org.pknu.weather.service.supports.AlarmTimeUtil;
-import org.pknu.weather.service.supports.WeatherRefresherService;
+import org.pknu.weather.service.WeatherRefresherService;
 
 @ExtendWith(MockitoExtension.class)
 class WeatherSummaryAlarmHandlerTest {

--- a/back/src/test/java/org/pknu/weather/service/message/LiveRainAlarmMessageMakerTest.java
+++ b/back/src/test/java/org/pknu/weather/service/message/LiveRainAlarmMessageMakerTest.java
@@ -1,0 +1,155 @@
+package org.pknu.weather.service.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import org.junit.jupiter.api.Test;
+import org.pknu.weather.domain.common.AlarmType;
+import org.pknu.weather.service.dto.AlarmInfo;
+import org.pknu.weather.service.dto.LiveRainAlarmInfo;
+import org.pknu.weather.service.dto.WeatherSummaryAlarmInfo;
+import org.pknu.weather.service.sender.FcmMessage;
+
+class LiveRainAlarmMessageMakerTest {
+
+    private LiveRainAlarmMessageMaker messageMaker = new LiveRainAlarmMessageMaker();
+
+
+    @Test
+    void 게시글_내용_없는_알림_메시지를_성공적으로_생성한다() {
+        // Given
+        LiveRainAlarmInfo info = LiveRainAlarmInfo.builder()
+                .fcmToken("test_fcm_token_1")
+                .province("서울특별시")
+                .city("마포구")
+                .street("상수동")
+                .postContent(null) // 게시글 내용 없음
+                .build();
+
+        // When
+        FcmMessage message = messageMaker.createAlarmMessage(info);
+
+
+        // Then
+        assertThat(message).isNotNull()
+                .satisfies(msg -> {
+                    assertThat(msg.getFcmToken()).isEqualTo("test_fcm_token_1");
+                    assertThat(msg.getAlarmTitle()).isEqualTo(AlarmType.RAIN_ALERT.getDescription());
+                    assertThat(msg.getAlarmMessage()).isNotNull();
+                });
+    }
+
+    @Test
+    void 게시글_내용_있는_알림_메시지를_성공적으로_생성한다() {
+        // Given
+        LiveRainAlarmInfo info = LiveRainAlarmInfo.builder()
+                .fcmToken("test_fcm_token_2")
+                .province("충청북도")
+                .city("청주시")
+                .street("서원구")
+                .postContent("지금 천둥 번개 치면서 비가 엄청 쏟아져요!") // 게시글 내용 있음
+                .build();
+
+        // When
+        FcmMessage message = messageMaker.createAlarmMessage(info);
+
+        // Then
+
+        assertThat(message).isNotNull()
+                .satisfies(msg -> {
+                    assertThat(msg.getFcmToken()).isEqualTo("test_fcm_token_2");
+                    assertThat(msg.getAlarmTitle()).isEqualTo(AlarmType.RAIN_ALERT.getDescription());
+                    assertThat(msg.getAlarmMessage()).contains("지금 천둥 번개 치면서 비가 엄청 쏟아져요!");
+                });
+
+    }
+
+
+    @Test
+    void AlarmInfo_타입이_LiveRainAlarmInfo가_아닐_경우_IllegalArgumentException이_발생한다() {
+        // Given
+        AlarmInfo wrongTypeInfo = new WeatherSummaryAlarmInfo(null,null,null);
+
+        // When & Then
+        assertThatThrownBy(() -> messageMaker.validate(wrongTypeInfo))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("LivaRainAlarmMessageMaker는 LivaRainAlarmInfo만 처리할 수 있습니다.");
+    }
+
+    @Test
+    void fcmToken이_null일_경우_IllegalStateException이_발생한다() {
+        // Given
+        LiveRainAlarmInfo info = LiveRainAlarmInfo.builder()
+                .fcmToken(null)
+                .province("서울")
+                .city("마포구")
+                .street("상수동")
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> messageMaker.validate(info))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("fcmToken이 비어있습니다.");
+    }
+
+    @Test
+    void fcmToken이_비어있을_경우_IllegalStateException이_발생한다() {
+        // Given
+        LiveRainAlarmInfo info = LiveRainAlarmInfo.builder()
+                .fcmToken("") // 빈 fcmToken
+                .province("서울")
+                .city("마포구")
+                .street("상수동")
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> messageMaker.validate(info))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("fcmToken이 비어있습니다.");
+    }
+
+    @Test
+    void province가_비어있을_경우_IllegalStateException이_발생한다() {
+        // Given
+        LiveRainAlarmInfo info = LiveRainAlarmInfo.builder()
+                .fcmToken("some_token")
+                .province("") // 빈 province
+                .city("마포구")
+                .street("상수동")
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> messageMaker.validate(info))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void city가_비어있을_경우_IllegalStateException이_발생한다() {
+        // Given
+        LiveRainAlarmInfo info = LiveRainAlarmInfo.builder()
+                .fcmToken("some_token")
+                .province("서울")
+                .city("") // 빈 city
+                .street("상수동")
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> messageMaker.validate(info))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void street이_비어있을_경우_IllegalStateException이_발생한다() {
+        // Given
+        LiveRainAlarmInfo info = LiveRainAlarmInfo.builder()
+                .fcmToken("some_token")
+                .province("서울")
+                .city("마포구")
+                .street("") // 빈 street
+                .build();
+
+        // When & Then
+        assertThatThrownBy(() -> messageMaker.validate(info))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+}

--- a/back/src/test/java/org/pknu/weather/service/message/LiveRainAlarmMessageMakerTest.java
+++ b/back/src/test/java/org/pknu/weather/service/message/LiveRainAlarmMessageMakerTest.java
@@ -72,7 +72,7 @@ class LiveRainAlarmMessageMakerTest {
         // When & Then
         assertThatThrownBy(() -> messageMaker.validate(wrongTypeInfo))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("LivaRainAlarmMessageMaker는 LivaRainAlarmInfo만 처리할 수 있습니다.");
+                .hasMessageContaining("LiveRainAlarmMessageMaker는 LiveRainAlarmInfo만 처리할 수 있습니다.");
     }
 
     @Test

--- a/back/src/test/java/org/pknu/weather/service/message/WeatherSummaryMessageMakerTest.java
+++ b/back/src/test/java/org/pknu/weather/service/message/WeatherSummaryMessageMakerTest.java
@@ -42,7 +42,7 @@ class WeatherSummaryMessageMakerTest {
                 .maxUvValue(2)
                 .build();
 
-        WeatherSummaryAlarmInfo alarmInfo =new WeatherSummaryAlarmInfo(weatherDTO, extraDTO, memberDTO);
+        WeatherSummaryAlarmInfo alarmInfo = new WeatherSummaryAlarmInfo(weatherDTO, extraDTO, memberDTO);
 
         // when
         FcmMessage result = maker.createAlarmMessage(alarmInfo);

--- a/back/src/test/resources/application.yml
+++ b/back/src/test/resources/application.yml
@@ -40,6 +40,12 @@ spring:
       location: /uploadImg
       max-request-size: 30MB
       max-file-size: 10MB
+  data:
+    redis:
+      host: localhost
+      port: 63790
+
+
 logging:
   level:
     root: debug


### PR DESCRIPTION
### 이슈 번호(링크)
`ex. Closes #123`

Closes #419 

### PR 요약 혹은 설명
## 요구 사항 정의
### 실시간 비 알림 기능 설명
* 유저가 비 태그가 포함된 소식을 공유했을 경우 해당 지역의 실시간 비 알림을 동의한 유저들에게 알림을 보낸다.
    * 게시물의 내용이 있을 경우 해당 내용을 포함해서 알림을 전송한다.
    * 태그만 공유할 경우에는 소식을 공유했단 알림만 전송한다.
* 알림을 받은 유저는 4시간 동안 자신의 지역에 비 태그가 포함된 게시글이 생성되어도 알림을 받지 않는다.

## 주요 변경 내용

**AlarmEventListener**
**LiveRainAlarmHandler**
**AlarmCooldownService**
**LiveRainAlarmMessageMaker**

**알람의 비동기 처리**
**알림의 쿨다운을 위한 redis 도입**
￼
## 상세 변경 내용

### AlarmEventListener

* **역할:** `LiveRainAlarmCreatedEvent` 이벤트가 발생한(`PostService.createWeatherPost()`실행) 후, 트랜잭션이 커밋되면 `AlarmService`를 통해 알림을 비동기적으로 트리거합니다.
* **구현:** Spring의 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)` 어노테이션을 사용하여 트랜잭션 커밋 이후에 이벤트를 처리하도록 설정되어 있습니다. 또한,`Async("AlarmExecutor")`를 통해 별도의 스레드 풀에서 비동기적으로 실행되어 게시글 저장 기능의 성능에 영향을 주지 않도록 했습니다.

### LiveRainAlarmHandler

* **역할:** `LiveRainAlarmCreatedEvent`를 처리하여 실시간 비 알림을 전송합니다. 
* **구현:** `AlarmCooldownService`를 사용하여 쿨다운 중인 사용자에게는 알림을 보내지 않도록 필터링하며, 알림 메시지를 생성하고 전송합니다. 알림을 보낸 다음에는 사용자를 쿨다운 상태로 저장합니다.

### AlarmCooldownService

* **역할:** 사용자의 쿨다운 상태를 관리합니다. 알림이 너무 자주 전송되는 것을 방지하기 위해, Redis를 사용하여 특정 시간 동안 알림 전송을 제한하는 기능을 제공합니다.
* **구현:**  RedisTemplate을 사용하여 쿨다운 상태를 Redis에 저장하고 조회합니다. 
    * `isInCooldown()` 메서드는 주어진 알림 유형과 식별자에 해당하는 키가 Redis에 존재하는지 확인하여 쿨다운 상태 여부를 반환합니다. 
    * `setCooldown()` 메서드는 지정된 알림 유형과 식별자에 대해 기본 4시간 쿨다운을 설정합니다. 
    * Redis 키는 alarm:cooldown:[알림타입]:[식별자] 형식의 네이밍 전략을 사용했습니다.

### 기타 사항
* 레디스의 테스트를 위해서 임베디드 레디스를 도입했습니다.

## 리뷰어 참고 및 논의 사항

