### PR TITLE
[BE/Fix] 알람 설정 조회 api 수정

### DIFF
--- a/back/src/main/java/org/pknu/weather/controller/AlarmControllerV2.java
+++ b/back/src/main/java/org/pknu/weather/controller/AlarmControllerV2.java
@@ -42,10 +42,11 @@ public class AlarmControllerV2 {
         return ApiResponse.onSuccess();
     }
 
-    @GetMapping("/alarm")
-    public ApiResponse<Object> getAlarm(@RequestHeader("Authorization") String authorization) {
-        String email = TokenConverter.getEmailByToken(authorization);
-        AlarmResponseDTO foundAlarm = alarmService.getAlarm(email);
+    @PostMapping("/alarm/by-fcm")
+    public ApiResponse<Object> getAlarm(@RequestHeader("Authorization") String authorization,
+                                        @RequestBody Map<String, String> payload) {
+        String fcmToken = payload.get("fcmToken");
+        AlarmResponseDTO foundAlarm = alarmService.getAlarm(fcmToken);
         return ApiResponse.onSuccess(foundAlarm);
     }
 

--- a/back/src/main/java/org/pknu/weather/repository/AlarmRepository.java
+++ b/back/src/main/java/org/pknu/weather/repository/AlarmRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import org.pknu.weather.domain.Alarm;
 import org.pknu.weather.domain.Member;
-import org.pknu.weather.service.dto.LiveRainAlarmInfo;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,8 +14,8 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     Optional<Alarm> findByFcmTokenAndMember(String fcmToken, Member member);
 
     @EntityGraph(attributePaths = {"summaryAlarmTimes"})
-    @Query("SELECT a FROM Alarm a WHERE a.member = :member")
-    Optional<Alarm> findByMemberWithSummaryAlarmTimes(@Param("member") Member member);
+    @Query("SELECT a FROM Alarm a WHERE a.fcmToken = :fcmToken")
+    Optional<Alarm> findByfcmTokenWithSummaryAlarmTimes(@Param("fcmToken") String fcmToken);
 
 
     @Query("SELECT a.fcmToken " +

--- a/back/src/main/java/org/pknu/weather/service/AlarmService.java
+++ b/back/src/main/java/org/pknu/weather/service/AlarmService.java
@@ -55,9 +55,8 @@ public class AlarmService {
         alarmRepository.saveAndFlush(modifiedAlarm);
     }
 
-    public AlarmResponseDTO getAlarm(String email) {
-        Member member = memberRepository.findMemberByEmail(email).orElseThrow(() -> new GeneralException(ErrorStatus._MEMBER_NOT_FOUND));
-        Alarm foundAlarm = alarmRepository.findByMemberWithSummaryAlarmTimes(member)
+    public AlarmResponseDTO getAlarm(String fcmToken) {
+        Alarm foundAlarm = alarmRepository.findByfcmTokenWithSummaryAlarmTimes(fcmToken)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._ALARM_NOT_FOUND));
 
         return toAlarmResponseDto(foundAlarm);


### PR DESCRIPTION
### 이슈 번호(링크)
`ex. Closes #123`

Closes #433 

### PR 요약 혹은 설명
- 알람 설정 조회 시, 기존의 멤버를 통한 조회는 여러 알람 정보를 조회하는 문제가 발생했습니다.
- 따라서, fcmToken을 통해 알람 설정 정보를 조회하도록 수정합니다.
