### PR TITLE
[BE/Fix] fcm토큰과 유저 정보로 알람을 조회하도록 수정

### DIFF
--- a/back/src/main/java/org/pknu/weather/controller/AlarmControllerV2.java
+++ b/back/src/main/java/org/pknu/weather/controller/AlarmControllerV2.java
@@ -45,8 +45,10 @@ public class AlarmControllerV2 {
     @PostMapping("/alarm/by-fcm")
     public ApiResponse<Object> getAlarm(@RequestHeader("Authorization") String authorization,
                                         @RequestBody Map<String, String> payload) {
+
+        String email = TokenConverter.getEmailByToken(authorization);
         String fcmToken = payload.get("fcmToken");
-        AlarmResponseDTO foundAlarm = alarmService.getAlarm(fcmToken);
+        AlarmResponseDTO foundAlarm = alarmService.getAlarm(email, fcmToken);
         return ApiResponse.onSuccess(foundAlarm);
     }
 

--- a/back/src/main/java/org/pknu/weather/repository/AlarmRepository.java
+++ b/back/src/main/java/org/pknu/weather/repository/AlarmRepository.java
@@ -11,12 +11,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
-    Optional<Alarm> findByFcmTokenAndMember(String fcmToken, Member member);
-
     @EntityGraph(attributePaths = {"summaryAlarmTimes"})
-    @Query("SELECT a FROM Alarm a WHERE a.fcmToken = :fcmToken")
-    Optional<Alarm> findByfcmTokenWithSummaryAlarmTimes(@Param("fcmToken") String fcmToken);
-
+    Optional<Alarm> findByFcmTokenAndMember(String fcmToken, Member member);
 
     @Query("SELECT a.fcmToken " +
             "FROM Alarm a JOIN a.member m JOIN m.location l " +

--- a/back/src/main/java/org/pknu/weather/service/AlarmService.java
+++ b/back/src/main/java/org/pknu/weather/service/AlarmService.java
@@ -55,9 +55,10 @@ public class AlarmService {
         alarmRepository.saveAndFlush(modifiedAlarm);
     }
 
-    public AlarmResponseDTO getAlarm(String fcmToken) {
-        Alarm foundAlarm = alarmRepository.findByfcmTokenWithSummaryAlarmTimes(fcmToken)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._ALARM_NOT_FOUND));
+    public AlarmResponseDTO getAlarm(String email, String fcmToken) {
+        Member member = memberRepository.safeFindByEmail(email);
+        Alarm foundAlarm = alarmRepository.findByFcmTokenAndMember(fcmToken,member)
+                .orElseThrow(() -> new GeneralException(ErrorStatus._FCMTOKEN_NOT_FOUND));
 
         return toAlarmResponseDto(foundAlarm);
     }


### PR DESCRIPTION
### 이슈 번호(링크)
`ex. Closes #123`

Closes #433 

### PR 요약 혹은 설명
- 한 기기안에 여러 유저가 로그인하여 사용하는 경우 문제가 발생하기 때문에 fcm토큰과 유저 정보를 토대로 알람을 조회하도록 수정합니다.
